### PR TITLE
Fixing issue of bar chart not being able to handle data of all 0 values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/go-ole/go-ole v1.2.4 // indirect
+	github.com/mattn/go-runewidth v0.0.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/shirou/gopsutil v2.20.6+incompatible
 	github.com/spf13/cobra v1.0.0

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -3,6 +3,7 @@ package process
 import (
 	ui "github.com/gizak/termui/v3"
 	"github.com/gizak/termui/v3/widgets"
+	"github.com/pesos/grofer/src/utils"
 )
 
 // PerProcPage holds the ui elements rendered by the command grofer proc -p PID
@@ -12,9 +13,9 @@ type PerProcPage struct {
 	MemChart         *widgets.Gauge
 	PIDTable         *widgets.Table
 	ChildProcsList   *widgets.List
-	CTXSwitchesChart *widgets.BarChart
-	PageFaultsChart  *widgets.BarChart
-	MemStatsChart    *widgets.BarChart
+	CTXSwitchesChart *utils.BarChart
+	PageFaultsChart  *utils.BarChart
+	MemStatsChart    *utils.BarChart
 }
 
 // NewProcPage initializes a new page from the PerProcPage struct and returns it
@@ -25,9 +26,9 @@ func NewPerProcPage() *PerProcPage {
 		MemChart:         widgets.NewGauge(),
 		PIDTable:         widgets.NewTable(),
 		ChildProcsList:   widgets.NewList(),
-		CTXSwitchesChart: widgets.NewBarChart(),
-		PageFaultsChart:  widgets.NewBarChart(),
-		MemStatsChart:    widgets.NewBarChart(),
+		CTXSwitchesChart: utils.NewBarChart(),
+		PageFaultsChart:  utils.NewBarChart(),
+		MemStatsChart:    utils.NewBarChart(),
 	}
 	page.InitPerProc()
 	return page

--- a/src/utils/barGraph.go
+++ b/src/utils/barGraph.go
@@ -40,6 +40,9 @@ func (self *BarChart) Draw(buf *Buffer) {
 	maxVal := self.MaxVal
 	if maxVal == 0 {
 		maxVal, _ = GetMaxFloat64FromSlice(self.Data)
+		if maxVal == 0 {
+			maxVal = 1
+		}
 	}
 
 	barXCoordinate := self.Inner.Min.X

--- a/src/utils/barGraph.go
+++ b/src/utils/barGraph.go
@@ -1,0 +1,85 @@
+package utils
+
+import (
+	"fmt"
+	"image"
+
+	rw "github.com/mattn/go-runewidth"
+
+	. "github.com/gizak/termui/v3"
+)
+
+type BarChart struct {
+	Block
+	BarColors    []Color
+	LabelStyles  []Style
+	NumStyles    []Style // only Fg and Modifier are used
+	NumFormatter func(float64) string
+	Data         []float64
+	Labels       []string
+	BarWidth     int
+	BarGap       int
+	MaxVal       float64
+}
+
+func NewBarChart() *BarChart {
+	return &BarChart{
+		Block:        *NewBlock(),
+		BarColors:    Theme.BarChart.Bars,
+		NumStyles:    Theme.BarChart.Nums,
+		LabelStyles:  Theme.BarChart.Labels,
+		NumFormatter: func(n float64) string { return fmt.Sprint(n) },
+		BarGap:       1,
+		BarWidth:     3,
+	}
+}
+
+func (self *BarChart) Draw(buf *Buffer) {
+	self.Block.Draw(buf)
+
+	maxVal := self.MaxVal
+	if maxVal == 0 {
+		maxVal, _ = GetMaxFloat64FromSlice(self.Data)
+	}
+
+	barXCoordinate := self.Inner.Min.X
+
+	for i, data := range self.Data {
+		// draw bar
+		height := int((data / maxVal) * float64(self.Inner.Dy()-1))
+		for x := barXCoordinate; x < MinInt(barXCoordinate+self.BarWidth, self.Inner.Max.X); x++ {
+			for y := self.Inner.Max.Y - 2; y > (self.Inner.Max.Y-2)-height; y-- {
+				c := NewCell(' ', NewStyle(ColorClear, SelectColor(self.BarColors, i)))
+				buf.SetCell(c, image.Pt(x, y))
+			}
+		}
+
+		// draw label
+		if i < len(self.Labels) {
+			labelXCoordinate := barXCoordinate +
+				int((float64(self.BarWidth) / 2)) -
+				int((float64(rw.StringWidth(self.Labels[i])) / 2))
+			buf.SetString(
+				self.Labels[i],
+				SelectStyle(self.LabelStyles, i),
+				image.Pt(labelXCoordinate, self.Inner.Max.Y-1),
+			)
+		}
+
+		// draw number
+		numberXCoordinate := barXCoordinate + int((float64(self.BarWidth) / 2))
+		if numberXCoordinate <= self.Inner.Max.X {
+			buf.SetString(
+				self.NumFormatter(data),
+				NewStyle(
+					SelectStyle(self.NumStyles, i+1).Fg,
+					SelectColor(self.BarColors, i),
+					SelectStyle(self.NumStyles, i+1).Modifier,
+				),
+				image.Pt(numberXCoordinate, self.Inner.Max.Y-2),
+			)
+		}
+
+		barXCoordinate += (self.BarWidth + self.BarGap)
+	}
+}


### PR DESCRIPTION
# Description

Implemented a custom bar chart in utils.go which ensures maxVal is never 0 to avoid 0/0 divisions.

Fixes #17 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
