### PR TITLE
fix proportion of procRefreshRate

### DIFF
--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -81,7 +81,7 @@ Syntax:
 
 			wg.Add(2)
 
-			go process.ServeProcs(dataChannel, endChannel, int32(2*procRefreshRate/5), &wg)
+			go process.ServeProcs(dataChannel, endChannel, int32(4*procRefreshRate/5), &wg)
 			go procGraph.AllProcVisuals(dataChannel, endChannel, procRefreshRate, &wg)
 			wg.Wait()
 		}

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -189,7 +189,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 			
 			ui.Render(myPage.Grid)
 
-            if previousKey == "g" {
+			if previousKey == "g" {
 				previousKey = ""
 			} else {
 				previousKey = e.ID

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -161,6 +161,8 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 				ui.Close()
 				wg.Done()
 				return
+			case "<Resize>":
+				updateUI()  // updateUI in resize event
 			case "s": //s to pause
 				pause()
 			case "j", "<Down>":
@@ -184,17 +186,17 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 			case "G", "<End>":
 				myPage.BodyList.ScrollBottom()
 			}
+			ui.Render(myPage.Grid)
 
 			updateUI() // Update UI to show scroll
 
 		case data := <-dataChannel:
 			myPage.BodyList.SelectedRowStyle = selectedStyle
 			if runAllProc {
-
 				myPage.BodyList.Rows = getData(data)
 			}
 		case <-tick: // Update page with new values
-			updateUI()
+			ui.Render(myPage.Grid)
 		}
 	}
 }

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -162,7 +162,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 				wg.Done()
 				return
 			case "<Resize>":
-				updateUI()  // updateUI in resize event
+				updateUI()  // updateUI only during resize event
 			case "s": //s to pause
 				pause()
 			case "j", "<Down>":
@@ -186,6 +186,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 			case "G", "<End>":
 				myPage.BodyList.ScrollBottom()
 			}
+			
 			ui.Render(myPage.Grid)
 
             if previousKey == "g" {

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -162,7 +162,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 				wg.Done()
 				return
 			case "<Resize>":
-				updateUI()  // updateUI only during resize event
+				updateUI() // updateUI only during resize event
 			case "s": //s to pause
 				pause()
 			case "j", "<Down>":
@@ -186,14 +186,14 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 			case "G", "<End>":
 				myPage.BodyList.ScrollBottom()
 			}
-			
-			ui.Render(myPage.Grid)
 
+			ui.Render(myPage.Grid)
 			if previousKey == "g" {
 				previousKey = ""
 			} else {
 				previousKey = e.ID
 			}
+
 		case data := <-dataChannel:
 			myPage.BodyList.SelectedRowStyle = selectedStyle
 			if runAllProc {

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -188,8 +188,11 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 			}
 			ui.Render(myPage.Grid)
 
-			updateUI() // Update UI to show scroll
-
+            if previousKey == "g" {
+				previousKey = ""
+			} else {
+				previousKey = e.ID
+			}
 		case data := <-dataChannel:
 			myPage.BodyList.SelectedRowStyle = selectedStyle
 			if runAllProc {

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -165,8 +165,9 @@ func ProcVisuals(endChannel chan os.Signal,
 		case <-tick:
 			w, h := ui.TerminalDimensions()
 			ui.Clear()
-			myPage.Grid.SetRect(-1, 0, w, h)
+			myPage.Grid.SetRect(0, 0, w, h)
 			ui.Render(myPage.Grid)
 		}
 	}
 }
+

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -170,4 +170,3 @@ func ProcVisuals(endChannel chan os.Signal,
 		}
 	}
 }
-

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -87,11 +87,6 @@ func ProcVisuals(endChannel chan os.Signal,
 				ui.Close()
 				wg.Done()
 				return
-			case  "<Resize>":
-				w, h := ui.TerminalDimensions()
-				ui.Clear()
-				myPage.Grid.SetRect(-1, 0, w, h)
-			    ui.Render(myPage.Grid)
 			case "s": //s to pause
 				pause()
 			case "j", "<Down>":
@@ -168,6 +163,9 @@ func ProcVisuals(endChannel chan os.Signal,
 			}
 
 		case <-tick:
+			w, h := ui.TerminalDimensions()
+			ui.Clear()
+			myPage.Grid.SetRect(-1, 0, w, h)
 			ui.Render(myPage.Grid)
 		}
 	}

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -87,6 +87,11 @@ func ProcVisuals(endChannel chan os.Signal,
 				ui.Close()
 				wg.Done()
 				return
+			case  "<Resize>":
+				w, h := ui.TerminalDimensions()
+				ui.Clear()
+				myPage.Grid.SetRect(-1, 0, w, h)
+			    ui.Render(myPage.Grid)
 			case "s": //s to pause
 				pause()
 			case "j", "<Down>":
@@ -163,9 +168,6 @@ func ProcVisuals(endChannel chan os.Signal,
 			}
 
 		case <-tick:
-			w, h := ui.TerminalDimensions()
-			ui.Clear()
-			myPage.Grid.SetRect(0, 0, w, h)
 			ui.Render(myPage.Grid)
 		}
 	}


### PR DESCRIPTION
# Description

Fixes refresh rate sent to `ServeProcs` as 0.8 times `procRefreshRate` for better CPU Performance of `grofer proc` (at 15% now)
Also fixed previous bug of "gg" key event not working and refactored Resizing code to it's event handler for updating UI.

Partly fixes High CPU, more optimizations needed

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))