### PR TITLE
Add feature for more CPU info

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 
 	overallGraph "github.com/pesos/grofer/src/display/general"
 	"github.com/pesos/grofer/src/general"
+	info "github.com/pesos/grofer/src/general"
 	"github.com/pesos/grofer/src/utils"
 )
 
@@ -40,10 +41,17 @@ var rootCmd = &cobra.Command{
 	Use:   "grofer",
 	Short: "grofer is a system profiler written in golang",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		overallRefreshRate, _ := cmd.Flags().GetInt32("refresh")
 		if overallRefreshRate < 1000 {
 			return fmt.Errorf("invalid refresh rate: minimum refresh rate is 1000(ms)")
+		}
+
+		cpuLoadFlag, _ := cmd.Flags().GetBool("cpuinfo")
+		if cpuLoadFlag {
+			cpuLoad := info.NewCPULoad()
+			dataChannel := make(chan *info.CPULoad, 1)
+			endChannel := make(chan os.Signal, 1)
+			return info.GetCPULoad(cpuLoad, dataChannel, endChannel, overallRefreshRate)
 		}
 
 		var wg sync.WaitGroup
@@ -73,6 +81,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.grofer.yaml)")
 
 	rootCmd.Flags().Int32P("refresh", "r", DefaultOverallRefreshRate, "Overall stats UI refreshes rate in milliseconds greater than 1000")
+	rootCmd.Flags().BoolP("cpuinfo", "c", false, "Info about the CPU Load over all CPUs")
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,7 @@ require (
 	github.com/shirou/gopsutil v2.20.6+incompatible
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0
+	github.com/thedevsaddam/gojsonq/v2 v2.5.2
+	github.com/tidwall/gjson v1.6.0
 	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -204,6 +204,16 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/thedevsaddam/gojsonq v1.9.1 h1:zQulEP43nwmq5EKrNWyIgJVbqDeMdC1qzXM/f5O15a0=
+github.com/thedevsaddam/gojsonq v2.3.0+incompatible h1:i2lFTvGY4LvoZ2VUzedsFlRiyaWcJm3Uh6cQ9+HyQA8=
+github.com/thedevsaddam/gojsonq/v2 v2.5.2 h1:CoMVaYyKFsVj6TjU6APqAhAvC07hTI6IQen8PHzHYY0=
+github.com/thedevsaddam/gojsonq/v2 v2.5.2/go.mod h1:bv6Xa7kWy82uT0LnXPE2SzGqTj33TAEeR560MdJkiXs=
+github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
+github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
+github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/src/display/general/init.go
+++ b/src/display/general/init.go
@@ -32,6 +32,19 @@ type MainPage struct {
 	NetPara      *widgets.Paragraph
 }
 
+type CPUPage struct {
+	Grid        *ui.Grid
+	UsrChart    *widgets.Gauge
+	NiceChart   *widgets.Gauge
+	SysChart    *widgets.Gauge
+	IowaitChart *widgets.Gauge
+	IrqChart    *widgets.Gauge
+	SoftChart   *widgets.Gauge
+	IdleChart   *widgets.Gauge
+	StealChart  *widgets.Gauge
+	CPUChart    *widgets.Table
+}
+
 // NewPage returns a new page initialized from the MainPage struct
 func NewPage(numCores int) *MainPage {
 	page := &MainPage{
@@ -43,6 +56,23 @@ func NewPage(numCores int) *MainPage {
 		NetPara:      widgets.NewParagraph(),
 	}
 	page.InitGeneral(numCores)
+	return page
+}
+
+func NewCPUPage(numCores int) *CPUPage {
+	page := &CPUPage{
+		Grid:        ui.NewGrid(),
+		UsrChart:    widgets.NewGauge(),
+		NiceChart:   widgets.NewGauge(),
+		SysChart:    widgets.NewGauge(),
+		IowaitChart: widgets.NewGauge(),
+		IrqChart:    widgets.NewGauge(),
+		SoftChart:   widgets.NewGauge(),
+		IdleChart:   widgets.NewGauge(),
+		StealChart:  widgets.NewGauge(),
+		CPUChart:    widgets.NewTable(),
+	}
+	page.InitCPU(numCores)
 	return page
 }
 
@@ -107,4 +137,90 @@ func (page *MainPage) InitGeneral(numCores int) {
 	// Get Terminal Dimensions
 	w, h := ui.TerminalDimensions()
 	page.Grid.SetRect(w/2, 0, w, h)
+}
+
+func (page *CPUPage) InitCPU(numCores int) {
+	page.UsrChart.Title = " Usr "
+	page.UsrChart.Percent = 0
+	page.UsrChart.BarColor = ui.ColorBlue
+	page.UsrChart.BorderStyle.Fg = ui.ColorCyan
+	page.UsrChart.TitleStyle.Fg = ui.ColorWhite
+
+	page.NiceChart.Title = " Nice "
+	page.NiceChart.Percent = 0
+	page.NiceChart.BarColor = ui.ColorBlue
+	page.NiceChart.BorderStyle.Fg = ui.ColorCyan
+	page.NiceChart.TitleStyle.Fg = ui.ColorWhite
+
+	page.SysChart.Title = " Sys "
+	page.SysChart.Percent = 0
+	page.SysChart.BarColor = ui.ColorBlue
+	page.SysChart.BorderStyle.Fg = ui.ColorCyan
+	page.SysChart.TitleStyle.Fg = ui.ColorWhite
+
+	page.IowaitChart.Title = " Iowait "
+	page.IowaitChart.Percent = 0
+	page.IowaitChart.BarColor = ui.ColorBlue
+	page.IowaitChart.BorderStyle.Fg = ui.ColorCyan
+	page.IowaitChart.TitleStyle.Fg = ui.ColorWhite
+
+	page.IrqChart.Title = " Irq "
+	page.IrqChart.Percent = 0
+	page.IrqChart.BarColor = ui.ColorBlue
+	page.IrqChart.BorderStyle.Fg = ui.ColorCyan
+	page.IrqChart.TitleStyle.Fg = ui.ColorWhite
+
+	page.SoftChart.Title = " Soft "
+	page.SoftChart.Percent = 0
+	page.SoftChart.BarColor = ui.ColorBlue
+	page.SoftChart.BorderStyle.Fg = ui.ColorCyan
+	page.SoftChart.TitleStyle.Fg = ui.ColorWhite
+
+	page.IdleChart.Title = " Idle "
+	page.IdleChart.Percent = 0
+	page.IdleChart.BarColor = ui.ColorBlue
+	page.IdleChart.BorderStyle.Fg = ui.ColorCyan
+	page.IdleChart.TitleStyle.Fg = ui.ColorWhite
+
+	page.StealChart.Title = " Steal "
+	page.StealChart.Percent = 0
+	page.StealChart.BarColor = ui.ColorBlue
+	page.StealChart.BorderStyle.Fg = ui.ColorCyan
+	page.StealChart.TitleStyle.Fg = ui.ColorWhite
+
+	page.CPUChart.Title = " CPU "
+	page.CPUChart.TextStyle = ui.NewStyle(ui.ColorWhite)
+	page.CPUChart.TextAlignment = ui.AlignCenter
+	page.CPUChart.RowSeparator = true
+
+	columnWidths := []int{}
+	for i := 0; i < numCores; i++ {
+		columnWidths = append(columnWidths, 9)
+	}
+
+	page.CPUChart.ColumnWidths = columnWidths
+
+	page.Grid.Set(
+		ui.NewRow(0.17,
+			ui.NewCol(0.5, page.UsrChart),
+			ui.NewCol(0.5, page.NiceChart),
+		),
+		ui.NewRow(0.17,
+			ui.NewCol(0.5, page.SysChart),
+			ui.NewCol(0.5, page.IowaitChart),
+		),
+		ui.NewRow(0.17,
+			ui.NewCol(0.5, page.IrqChart),
+			ui.NewCol(0.5, page.SoftChart),
+		),
+		ui.NewRow(0.17,
+			ui.NewCol(0.5, page.IdleChart),
+			ui.NewCol(0.5, page.StealChart),
+		),
+		ui.NewRow(0.30, page.CPUChart),
+	)
+
+	w, h := ui.TerminalDimensions()
+	page.Grid.SetRect(0, 0, w, h)
+
 }

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -107,7 +107,7 @@ func getData(procs []*proc.Process) []string {
 				createTime := utils.GetDateFromUnix(ctime)
 				temp = temp + createTime
 			}
-			for i := 0; i < 24-len(createTime); i++ {
+			for i := 0; i < 9-len(createTime); i++ {
 				temp = temp + " "
 			}
 

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -31,7 +31,6 @@ import (
 )
 
 var runAllProc = true
-var on1 sync.Once
 
 func getData(procs []*proc.Process) []string {
 	var data []string
@@ -132,6 +131,8 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 		log.Fatalf("failed to initialize termui: %v", err)
 	}
 
+	var on sync.Once
+
 	myPage := NewAllProcsPage()
 
 	updateUI := func() {
@@ -200,7 +201,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 			if runAllProc {
 				myPage.BodyList.Rows = getData(data)
 
-				on1.Do(func() {
+				on.Do(func() {
 					w, h := ui.TerminalDimensions()
 					ui.Clear()
 					myPage.Grid.SetRect(0, 0, w, h)

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -28,7 +28,6 @@ import (
 )
 
 var runProc = true
-var on sync.Once
 
 func getChildProcs(proc *process.Process) []string {
 	childProcs := []string{"PID                   Command"}
@@ -58,6 +57,8 @@ func ProcVisuals(endChannel chan os.Signal,
 	if err := ui.Init(); err != nil {
 		log.Fatalf("failed to initialize termui: %v", err)
 	}
+
+	var on sync.Once
 
 	// Create new page
 	myPage := NewPerProcPage()

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -1,0 +1,89 @@
+/*
+Copyright © 2020 The PES Open Source Team pesos@pes.edu
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package general
+
+import (
+	"os"
+	"os/exec"
+	"time"
+
+	gjson "github.com/tidwall/gjson"
+)
+
+type CPULoad struct {
+	Usr    int64 `json:"usr"`
+	Nice   int64 `json:"nice"`
+	Sys    int64 `json:"sys"`
+	Iowait int64 `json:"iowait"`
+	Irq    int64 `json:"irq"`
+	Soft   int64 `json:"soft"`
+	Steal  int64 `json:"steal"`
+	Guest  int64 `json:"guest"`
+	Gnice  int64 `json:"gnice"`
+	Idle   int64 `json:"idle"`
+}
+
+func NewCPULoad() *CPULoad {
+	return &CPULoad{}
+}
+
+func (c *CPULoad) updateCPULoad() error {
+	mpstat := "mpstat"
+	arg0 := "-o"
+	arg1 := "JSON"
+	cmd := exec.Command(mpstat, arg0, arg1)
+	stdout, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+
+	statsExtract := gjson.Get(string(stdout), "sysstat.hosts.0.statistics.0.cpu-load.0")
+	stats := statsExtract.Map()
+	c.Usr = stats["usr"].Int()
+	c.Nice = stats["nice"].Int()
+	c.Sys = stats["sys"].Int()
+	c.Iowait = stats["iowait"].Int()
+	c.Irq = stats["irq"].Int()
+	c.Soft = stats["soft"].Int()
+	c.Steal = stats["steal"].Int()
+	c.Guest = stats["guest"].Int()
+	c.Gnice = stats["gnice"].Int()
+	c.Idle = stats["idle"].Int()
+
+	return nil
+}
+
+// GetCPULoad updated the CPULoad struct and serves the data to the data channel.
+func GetCPULoad(cpuLoad *CPULoad,
+	dataChannel chan *CPULoad,
+	endChannel chan os.Signal,
+	refreshRate int32) error {
+	for {
+		select {
+		case <-endChannel: // Stop execution if end signal received
+			return nil
+
+		default: // Get Memory and CPU rates per core periodically
+			err := cpuLoad.updateCPULoad()
+			if err != nil {
+				return err
+			}
+			dataChannel <- cpuLoad
+			time.Sleep(time.Duration(refreshRate) * time.Millisecond)
+		}
+	}
+}

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -24,17 +24,20 @@ import (
 	gjson "github.com/tidwall/gjson"
 )
 
+// CPULoad type contains info about load on CPU from various sources
+// as well as general stats about the CPU.
 type CPULoad struct {
-	Usr    int64 `json:"usr"`
-	Nice   int64 `json:"nice"`
-	Sys    int64 `json:"sys"`
-	Iowait int64 `json:"iowait"`
-	Irq    int64 `json:"irq"`
-	Soft   int64 `json:"soft"`
-	Steal  int64 `json:"steal"`
-	Guest  int64 `json:"guest"`
-	Gnice  int64 `json:"gnice"`
-	Idle   int64 `json:"idle"`
+	Usr      int64     `json:"usr"`
+	Nice     int64     `json:"nice"`
+	Sys      int64     `json:"sys"`
+	Iowait   int64     `json:"iowait"`
+	Irq      int64     `json:"irq"`
+	Soft     int64     `json:"soft"`
+	Steal    int64     `json:"steal"`
+	Guest    int64     `json:"guest"`
+	Gnice    int64     `json:"gnice"`
+	Idle     int64     `json:"idle"`
+	CPURates []float64 `json:"-"`
 }
 
 func NewCPULoad() *CPULoad {
@@ -63,6 +66,12 @@ func (c *CPULoad) updateCPULoad() error {
 	c.Guest = stats["guest"].Int()
 	c.Gnice = stats["gnice"].Int()
 	c.Idle = stats["idle"].Int()
+
+	cpuRates, err := GetCPURates()
+	if err != nil {
+		return err
+	}
+	c.CPURates = cpuRates
 
 	return nil
 }

--- a/src/general/printStats.go
+++ b/src/general/printStats.go
@@ -34,6 +34,14 @@ func roundOff(num uint64) float64 {
 	return math.Round(x*10) / 10
 }
 
+func GetCPURates() ([]float64, error) {
+	cpuRates, err := cpu.Percent(time.Second, true)
+	if err != nil {
+		return nil, err
+	}
+	return cpuRates, nil
+}
+
 // PrintCPURates print the cpu rates
 func PrintCPURates(cpuChannel chan utils.DataStats) {
 	cpuRates, err := cpu.Percent(time.Second, true)


### PR DESCRIPTION
# Description

Added features for more CPU information, this includes the following values:
* Usr
* Nice
* Sys
* Iowait
* Irq
* Soft
* Steal
* Idle

The above values are rendered on a different page along with per CPU usage rates, they can be accessed through the command `grofer -c`.


Fixes #21 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
