### PR TITLE
Fix duplicate errors with fmt.Println(err) deletion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,6 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
# Description

Cobra already shows errors.
Duplicates errors are due to `fmt.Println(err)` in the `func Execute()` in the `root.go` file. 

Fixes #8 

Fixed by: `fmt.Println(err)` deletion.


