### PR TITLE
Fix error handling under cmd/root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/thedevsaddam/gojsonq/v2 v2.5.2
 	github.com/tidwall/gjson v1.6.0
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -269,7 +269,10 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -17,11 +17,10 @@ limitations under the License.
 package general
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
-	"sync"
 	"time"
 
 	gjson "github.com/tidwall/gjson"
@@ -89,16 +88,14 @@ func (c *CPULoad) updateCPULoad() error {
 }
 
 // GetCPULoad updated the CPULoad struct and serves the data to the data channel.
-func GetCPULoad(cpuLoad *CPULoad,
+func GetCPULoad(ctx context.Context,
+	cpuLoad *CPULoad,
 	dataChannel chan *CPULoad,
-	endChannel chan os.Signal,
-	refreshRate int32,
-	wg *sync.WaitGroup) error {
+	refreshRate int32) error {
 	for {
 		select {
-		case <-endChannel: // Stop execution if end signal received
-			wg.Done()
-			return nil
+		case <-ctx.Done():
+			return ctx.Err()
 
 		default: // Get Memory and CPU rates per core periodically
 			err := cpuLoad.updateCPULoad()

--- a/src/general/errors.go
+++ b/src/general/errors.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2020 The PES Open Source Team pesos@pes.edu
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package general
 
 import (

--- a/src/general/errors.go
+++ b/src/general/errors.go
@@ -1,0 +1,7 @@
+package general
+
+import (
+	"errors"
+)
+
+var ErrCanceledByUser = errors.New("canceled by user")

--- a/src/general/generalStats.go
+++ b/src/general/generalStats.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pesos/grofer/src/utils"
 )
 
-type serveFunc func(chan utils.DataStats) error
+type serveFunc func(context.Context, chan utils.DataStats) error
 
 // GlobalStats gets stats about the mem and the CPUs and prints it.
 func GlobalStats(ctx context.Context,
@@ -51,7 +51,7 @@ func GlobalStats(ctx context.Context,
 				wg.Add(1)
 				go func(sf serveFunc, dc chan utils.DataStats) {
 					defer wg.Done()
-					errCh <- sf(dc)
+					errCh <- sf(ctx, dc)
 				}(sf, dataChannel)
 			}
 

--- a/src/general/generalStats.go
+++ b/src/general/generalStats.go
@@ -16,30 +16,54 @@ limitations under the License.
 package general
 
 import (
-	"os"
+	"context"
 	"sync"
 	"time"
 
 	"github.com/pesos/grofer/src/utils"
 )
 
+type serveFunc func(chan utils.DataStats) error
+
 // GlobalStats gets stats about the mem and the CPUs and prints it.
-func GlobalStats(endChannel chan os.Signal,
-	dataChannel chan utils.DataStats, refreshRate int32,
-	wg *sync.WaitGroup) {
+func GlobalStats(ctx context.Context,
+	dataChannel chan utils.DataStats,
+	refreshRate int32) error {
+
+	serveFuncs := []serveFunc{
+		ServeCPURates,
+		ServeMemRates,
+		ServeDiskRates,
+		ServeNetRates,
+	}
 
 	for {
 		select {
-		case <-endChannel: // Stop execution if end signal received
-			wg.Done()
-			return
+		case <-ctx.Done():
+			return ctx.Err()
 
 		default: // Get Memory and CPU rates per core periodically
+			var wg sync.WaitGroup
 
-			go ServeCPURates(dataChannel)
-			go ServeMemRates(dataChannel)
-			go ServeDiskRates(dataChannel)
-			ServeNetRates(dataChannel)
+			errCh := make(chan error, len(serveFuncs))
+
+			for _, sf := range serveFuncs {
+				wg.Add(1)
+				go func(sf serveFunc, dc chan utils.DataStats) {
+					defer wg.Done()
+					errCh <- sf(dc)
+				}(sf, dataChannel)
+			}
+
+			wg.Wait()
+			close(errCh)
+
+			for err := range errCh {
+				if err != nil {
+					return err
+				}
+			}
+
 			time.Sleep(time.Duration(refreshRate) * time.Millisecond)
 		}
 	}

--- a/src/general/serveStats.go
+++ b/src/general/serveStats.go
@@ -17,7 +17,6 @@ package general
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"strings"
 	"time"
@@ -44,23 +43,25 @@ func GetCPURates() ([]float64, error) {
 }
 
 // ServeCPURates serves the cpu rates to the cpu channel
-func ServeCPURates(cpuChannel chan utils.DataStats) {
+func ServeCPURates(cpuChannel chan utils.DataStats) error {
 	cpuRates, err := cpu.Percent(time.Second, true)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	data := utils.DataStats{
 		CpuStats: cpuRates,
 		FieldSet: "CPU",
 	}
 	cpuChannel <- data
+
+	return nil
 }
 
 // ServeMemRates serves stats about the memory to the data channel
-func ServeMemRates(dataChannel chan utils.DataStats) {
+func ServeMemRates(dataChannel chan utils.DataStats) error {
 	memory, err := mem.VirtualMemory()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	memRates := []float64{roundOff(memory.Total), roundOff(memory.Available), roundOff(memory.Used), roundOff(memory.Free)}
@@ -71,16 +72,18 @@ func ServeMemRates(dataChannel chan utils.DataStats) {
 	}
 
 	dataChannel <- data
+
+	return nil
 }
 
 // ServeDiskRates serves the disk rate data to the data channel
-func ServeDiskRates(dataChannel chan utils.DataStats) {
+func ServeDiskRates(dataChannel chan utils.DataStats) error {
 
 	var partitions []disk.PartitionStat
 	var err error
 	partitions, err = disk.Partitions(false)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	rows := [][]string{[]string{"Mount", "Total", "Used %", "Used", "Free", "FS Type"}}
@@ -111,13 +114,15 @@ func ServeDiskRates(dataChannel chan utils.DataStats) {
 	}
 
 	dataChannel <- data
+
+	return nil
 }
 
 // ServeNetRates serves info about the network to the data channel
-func ServeNetRates(dataChannel chan utils.DataStats) {
+func ServeNetRates(dataChannel chan utils.DataStats) error {
 	netStats, err := net.IOCounters(false)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	IO := make(map[string][]float64)
 	for _, IOStat := range netStats {
@@ -131,4 +136,6 @@ func ServeNetRates(dataChannel chan utils.DataStats) {
 	}
 
 	dataChannel <- data
+
+	return nil
 }


### PR DESCRIPTION
# Description

This PR fixes the way of error handling under `cmd/root`.

- When any error occurs, it will be returned to callers, which enables to handle it at the right place.
- Pressing `q` terminates execution in a right way.

Fixes #48 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
