### PR TITLE
Press F to kill

### DIFF
--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -60,7 +60,6 @@ Syntax:
 			return fmt.Errorf("invalid refresh rate: minimum refresh rate is 1000(ms)")
 		}
 
-
 		if pid != defaultProcPid {
 			dataChannel := make(chan *process.Process, 1)
 

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -169,7 +169,9 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 				myPage.BodyList.ScrollTop()
 			case "G", "<End>":
 				myPage.BodyList.ScrollBottom()
-			case "F", "<F9>":
+			case "K", "<F9>":
+				updateUI()
+
 				row := myPage.BodyList.Rows[myPage.BodyList.SelectedRow]
 				// get PID from the data
 				pid64, err := strconv.ParseInt(strings.SplitN(row, " ", 2)[0], 10, 32)
@@ -177,12 +179,15 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 					return fmt.Errorf("Failed to get PID of process: %v", err)
 				}
 				pid := int32(pid64)
+
 				// get process and kill it
 				procToKill, err := proc.NewProcess(pid)
-				if err != nil {
-					return fmt.Errorf("Failed to kill process with PID %d: %v", pid, err)
+				if err == nil {
+					err = procToKill.Kill()
+					if err != nil {
+						return fmt.Errorf("Failed to kill process with PID %d: %v", pid, err)
+					}
 				}
-				procToKill.Kill()
 			}
 
 			ui.Render(myPage.Grid)

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -32,7 +32,7 @@ import (
 
 var runAllProc = true
 
-func getData(procs []*proc.Process) []string {
+func getData(procs []*proc.Process) ([]string) {
 	var data []string
 	for _, info := range procs {
 		exe, err := info.Exe()
@@ -170,6 +170,14 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 				myPage.BodyList.ScrollTop()
 			case "G", "<End>":
 				myPage.BodyList.ScrollBottom()
+			case "F", "<F9>":
+				row := myPage.BodyList.Rows[myPage.BodyList.SelectedRow]
+				// get PID from the data
+				pid64, _ := strconv.ParseInt(strings.SplitN(row, " ", 2)[0], 10, 32)
+				pid := int32(pid64)
+				// get process and kill it
+				procToKill, _ := proc.NewProcess(pid)
+				procToKill.Kill()
 			}
 
 			ui.Render(myPage.Grid)

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -56,6 +56,8 @@ func ProcVisuals(ctx context.Context,
 	dataChannel chan *process.Process,
 	refreshRate uint64) error {
 
+	defer ui.Close()
+
 	if err := ui.Init(); err != nil {
 		log.Fatalf("failed to initialize termui: %v", err)
 	}

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -16,14 +16,15 @@ limitations under the License.
 package process
 
 import (
+	"context"
 	"log"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	ui "github.com/gizak/termui/v3"
+	info "github.com/pesos/grofer/src/general"
 	"github.com/pesos/grofer/src/process"
 	"github.com/pesos/grofer/src/utils"
 )
@@ -51,10 +52,9 @@ func getChildProcs(proc *process.Process) []string {
 }
 
 // ProcVisuals renders graphs and charts for per-process stats.
-func ProcVisuals(endChannel chan os.Signal,
+func ProcVisuals(ctx context.Context,
 	dataChannel chan *process.Process,
-	refreshRate uint64,
-	wg *sync.WaitGroup) {
+	refreshRate int32) error {
 
 	if err := ui.Init(); err != nil {
 		log.Fatalf("failed to initialize termui: %v", err)
@@ -110,10 +110,7 @@ func ProcVisuals(endChannel chan os.Signal,
 		case e := <-uiEvents:
 			switch e.ID {
 			case "q", "<C-c>": //q or Ctrl-C to quit
-				endChannel <- os.Kill
-				ui.Close()
-				wg.Done()
-				return
+				return info.ErrCanceledByUser
 			case "s": //s to pause
 				pause()
 			case "<Resize>":

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -54,7 +54,7 @@ func getChildProcs(proc *process.Process) []string {
 // ProcVisuals renders graphs and charts for per-process stats.
 func ProcVisuals(ctx context.Context,
 	dataChannel chan *process.Process,
-	refreshRate int32) error {
+	refreshRate uint64) error {
 
 	if err := ui.Init(); err != nil {
 		log.Fatalf("failed to initialize termui: %v", err)

--- a/src/process/serveData.go
+++ b/src/process/serveData.go
@@ -16,20 +16,18 @@ limitations under the License.
 package process
 
 import (
-	"os"
-	"sync"
+	"context"
 	"time"
 
 	proc "github.com/shirou/gopsutil/process"
 )
 
 // Serve serves data on a per process basis
-func Serve(process *Process, dataChannel chan *Process, endChannel chan os.Signal, refreshRate uint64, wg *sync.WaitGroup) {
+func Serve(process *Process, dataChannel chan *Process, ctx context.Context, refreshRate int32) error {
 	for {
 		select {
-		case <-endChannel:
-			wg.Done() // Stop execution if end signal received
-			return
+		case <-ctx.Done():
+			return ctx.Err() // Stop execution if end signal received
 
 		default:
 			process.UpdateProcInfo()
@@ -40,12 +38,11 @@ func Serve(process *Process, dataChannel chan *Process, endChannel chan os.Signa
 
 }
 
-func ServeProcs(dataChannel chan []*proc.Process, endChannel chan os.Signal, refreshRate uint64, wg *sync.WaitGroup) {
+func ServeProcs(dataChannel chan []*proc.Process, ctx context.Context, refreshRate int32) error {
 	for {
 		select {
-		case <-endChannel:
-			wg.Done()
-			return
+		case <-ctx.Done():
+			return ctx.Err() // Stop execution if end signal received
 
 		default:
 			procs, err := proc.Processes()


### PR DESCRIPTION
# Description

Added two keybindings to kill the selected process in `grofer proc`:
  - `K` (shift+K)
  - `<F9>` - because [htop](https://github.com/htop-dev/htop/) uses this keybind

Fixes #16 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
