### PR TITLE
inconsistent allignment in list of child process for gropher proc command

### DIFF
--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -38,7 +38,7 @@ func getChildProcs(proc *process.Process) []string {
 		processPid := strconv.Itoa(int(proc.Pid))
 		// 22 reflects position where row data for "Command" column should start (headerString has 19 spaces + length of ("PID") is 3 i.e. 22)
 		spacesForCommandRowData = strings.Repeat(" ", 22-len(processPid))
-		processData = "[" + processPid + "](fg:yellow)" + spacesForCommandRowData
+		processData = processPid + spacesForCommandRowData
 		exe, err := proc.Exe()
 		if err == nil {
 			processData += "[" + exe + "](fg:green)"
@@ -103,6 +103,8 @@ func ProcVisuals(endChannel chan os.Signal,
 	tick := time.Tick(time.Duration(refreshRate) * time.Millisecond)
 
 	previousKey := ""
+	selectedStyle := ui.NewStyle(ui.ColorYellow, ui.ColorClear, ui.ModifierBold)
+
 	for {
 		select {
 		case e := <-uiEvents:
@@ -147,6 +149,7 @@ func ProcVisuals(endChannel chan os.Signal,
 			}
 
 		case data := <-dataChannel:
+			myPage.ChildProcsList.SelectedRowStyle = selectedStyle
 			if runProc {
 				// update ctx switches
 				switches, units := utils.RoundValues(float64(data.NumCtxSwitches.Voluntary), float64(data.NumCtxSwitches.Involuntary))

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"strings"
 	"time"
 
 	ui "github.com/gizak/termui/v3"
@@ -30,21 +31,24 @@ import (
 var runProc = true
 
 func getChildProcs(proc *process.Process) []string {
-	childProcs := []string{"PID                   Command"}
-	for _, proc := range proc.Children {
-		exe, err := proc.Exe()
-		if err == nil {
-			temp := strconv.Itoa(int(proc.Pid))
-			for i := 0; i < 22-len(strconv.Itoa(int(proc.Pid))); i++ {
-				temp = temp + " "
+	headerString := "PID" + strings.Repeat(" ", 19) + "Command"
+	childProcs := []string{headerString}
+	for i, proc := range proc.Children {
+			var processData, spacesForCommandRowData string
+			processPid := strconv.Itoa(int(proc.Pid))
+			if i % 2 == 0 {
+					processPid += "321"
 			}
-			temp = temp + "[" + exe + "](fg:green)"
-			childProcs = append(childProcs, temp)
-		} else {
-			childProcs = append(childProcs, "["+strconv.Itoa(int(proc.Pid))+"](fg:yellow)"+"            "+"NA")
-		}
+			// 22 reflects position where row data for "Command" column should start (headerString has 19 spaces + length of ("PID") is 3 i.e. 22)
+			spacesForCommandRowData = strings.Repeat(" ", 22-len(processPid))
+			exe, err := proc.Exe()
+			if err == nil {
+					processData = processPid + spacesForCommandRowData + "[" + exe + "](fg:green)"
+			} else {
+					processData = "["+processPid+"](fg:yellow)" + spacesForCommandRowData + "NA"
+			}
+			childProcs = append(childProcs, processData)
 	}
-
 	return childProcs
 }
 

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -38,11 +38,12 @@ func getChildProcs(proc *process.Process) []string {
 		processPid := strconv.Itoa(int(proc.Pid))
 		// 22 reflects position where row data for "Command" column should start (headerString has 19 spaces + length of ("PID") is 3 i.e. 22)
 		spacesForCommandRowData = strings.Repeat(" ", 22-len(processPid))
+		processData = "[" + processPid + "](fg:yellow)" + spacesForCommandRowData
 		exe, err := proc.Exe()
 		if err == nil {
-			processData = processPid + spacesForCommandRowData + "[" + exe + "](fg:green)"
+			processData += "[" + exe + "](fg:green)"
 		} else {
-			processData = "[" + processPid + "](fg:yellow)" + spacesForCommandRowData + "NA"
+			processData += "NA"
 		}
 		childProcs = append(childProcs, processData)
 	}

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -19,8 +19,8 @@ import (
 	"log"
 	"os"
 	"strconv"
-	"sync"
 	"strings"
+	"sync"
 	"time"
 
 	ui "github.com/gizak/termui/v3"
@@ -33,21 +33,18 @@ var runProc = true
 func getChildProcs(proc *process.Process) []string {
 	headerString := "PID" + strings.Repeat(" ", 19) + "Command"
 	childProcs := []string{headerString}
-	for i, proc := range proc.Children {
-			var processData, spacesForCommandRowData string
-			processPid := strconv.Itoa(int(proc.Pid))
-			if i % 2 == 0 {
-					processPid += "321"
-			}
-			// 22 reflects position where row data for "Command" column should start (headerString has 19 spaces + length of ("PID") is 3 i.e. 22)
-			spacesForCommandRowData = strings.Repeat(" ", 22-len(processPid))
-			exe, err := proc.Exe()
-			if err == nil {
-					processData = processPid + spacesForCommandRowData + "[" + exe + "](fg:green)"
-			} else {
-					processData = "["+processPid+"](fg:yellow)" + spacesForCommandRowData + "NA"
-			}
-			childProcs = append(childProcs, processData)
+	for _, proc := range proc.Children {
+		var processData, spacesForCommandRowData string
+		processPid := strconv.Itoa(int(proc.Pid))
+		// 22 reflects position where row data for "Command" column should start (headerString has 19 spaces + length of ("PID") is 3 i.e. 22)
+		spacesForCommandRowData = strings.Repeat(" ", 22-len(processPid))
+		exe, err := proc.Exe()
+		if err == nil {
+			processData = processPid + spacesForCommandRowData + "[" + exe + "](fg:green)"
+		} else {
+			processData = "[" + processPid + "](fg:yellow)" + spacesForCommandRowData + "NA"
+		}
+		childProcs = append(childProcs, processData)
 	}
 	return childProcs
 }


### PR DESCRIPTION
# Description

1) Inconsistent allignment in list of child process for command `gropher proc -p 1`.
2) Follow list color-scheme as in AllProcPage

Fixes #45 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
