### PR TITLE
Add Cute ASCII for error messages!

### DIFF
--- a/src/utils/doggo.go
+++ b/src/utils/doggo.go
@@ -18,9 +18,28 @@ package utils
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 )
 
 func ErrorMsg() {
+	rand.Seed(time.Now().UnixNano())
+	num := rand.Intn(5)
+	switch num {
+	case 0:
+		ErrorDoggo()
+	case 1:
+		ErrorCatto()
+	case 2:
+		ErrorBunny()
+	case 3:
+		ErrorDolphy()
+	case 4:
+		ErrorOwl()
+	}
+}
+
+func ErrorDoggo() {
 	dog := `
 	pid no exist, done doggo a sad
 		\
@@ -35,4 +54,88 @@ func ErrorMsg() {
 		  || (___\====
 	`
 	fmt.Println(dog)
+}
+
+func ErrorOwl() {
+	goobes := `
+
+The council of wise owls are confused! Please provide a valid PID!
+
+   /\_/\       /\_/\        /\_/\        /\_/\
+  ((@v@))     ((@v@))      ((@v@))      ((@v@))
+ ():::::()   ():::::()    ():::::()    ():::::()
+   VV-VV       VV-VV        VV-VV        VV-VV
+  `
+	fmt.Println(goobes)
+}
+
+func ErrorCatto() {
+	cat := `
+Catto says PID is invalid, plis give valid PID
+    \
+     \
+  　██░▀██████████████▀░██
+　　█▌▒▒░████████████░▒▒▐█
+　　█░▒▒▒░██████████░▒▒▒░█
+　　▌░▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░▐
+　　░▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒░
+　 ███▀▀▀██▄▒▒▒▒▒▒▒▄██▀▀▀██
+　 ██░░░▐█░▀█▒▒▒▒▒█▀░█▌░░░█
+　 ▐▌░░░▐▄▌░▐▌▒▒▒▐▌░▐▄▌░░▐▌
+　　█░░░▐█▌░░▌▒▒▒▐░░▐█▌░░█
+　　▒▀▄▄▄█▄▄▄▌░▄░▐▄▄▄█▄▄▀▒
+　　░░░░░░░░░░└┴┘░░░░░░░░░
+　　██▄▄░░░░░░░░░░░░░░▄▄██
+　　████████▒▒▒▒▒▒████████
+　　█▀░░███▒▒░░▒░░▒▀██████
+　　█▒░███▒▒╖░░╥░░╓▒▐█████
+　　█▒░▀▀▀░░║░░║░░║░░█████
+　　██▄▄▄▄▀▀┴┴╚╧╧╝╧╧╝┴┴███
+　　██████████████████████`
+	fmt.Println(cat)
+}
+
+func ErrorDolphy() {
+	dolphy := `
+                               _.-~  )
+                    _..--~~~~,'   ,-/     _
+                 .-'. . . .'   ,-','    ,' )
+               ,'. . . _   ,--~,-'__..-'  ,'
+             ,'. . .  (@)' ---~~~~      ,'
+            /. . . . '~~             ,-'
+           /. . . . .             ,-'
+          ; . . . .  - .        ,'
+         : . . . .      \_     /       PID did Dolphy a daze,
+        . . . . .          \-.:        Please enter valid PID
+       . . . ./  - .          )
+      .  . . |  _____..---.._/ _____________
+~---~~~~----~~~~             ~~
+`
+	fmt.Println(dolphy)
+}
+
+func ErrorBunny() {
+	bunny := `             ,
+            /|      __
+           / |   ,-~ /
+          Y :|  //  /
+          | jj /( .^
+          >-"~"-v"
+         /       Y
+        jo  o    |
+       ( ~T~     j
+        >._-' _./
+       /   "~"  |
+      Y     _,  |
+     /| ;-"~ _  l
+    / l/ ,-"~    \
+    \//\/      .- \
+     Y        /    Y     Bunny couldn't recognise that PID.
+     l       I     !      Done bunny a confuse.
+     ]\      _\    /"\     Please give bunny a valid PID.
+    (" ~----( ~   Y.  )
+~~~~~~~~~~~~~~~~~~~~~~~~~
+  `
+
+	fmt.Println(bunny)
 }

--- a/src/utils/doggo.go
+++ b/src/utils/doggo.go
@@ -61,10 +61,13 @@ func ErrorOwl() {
 
 The council of wise owls are confused! Please provide a valid PID!
 
-   /\_/\       /\_/\        /\_/\        /\_/\
-  ((@v@))     ((@v@))      ((@v@))      ((@v@))
- ():::::()   ():::::()    ():::::()    ():::::()
-   VV-VV       VV-VV        VV-VV        VV-VV
+   /\_/\  The council of wise owls are confused!  /\_/\
+  ((@v@))      Please provide a valid PID!       ((@v@))
+ ():::::()                                      ():::::()
+   VV-VV          /\_/\         /\_/\             VV-VV
+                 ((@v@))       ((@v@))
+                ():::::()     ():::::()
+                  VV-VV         VV-VV
   `
 	fmt.Println(goobes)
 }

--- a/src/utils/errorArt.go
+++ b/src/utils/errorArt.go
@@ -59,8 +59,6 @@ func ErrorDoggo() {
 func ErrorOwl() {
 	goobes := `
 
-The council of wise owls are confused! Please provide a valid PID!
-
    /\_/\  The council of wise owls are confused!  /\_/\
   ((@v@))      Please provide a valid PID!       ((@v@))
  ():::::()                                      ():::::()


### PR DESCRIPTION
# Description

Added a bunch of cute ASCII art to be generated when invalid PIDs are provided to `grofer proc -p PID`

Added following images!

![image](https://user-images.githubusercontent.com/44526455/94954474-d071e580-0506-11eb-83ad-5a547ba943cf.png)

![image](https://user-images.githubusercontent.com/44526455/94954497-dcf63e00-0506-11eb-9d6f-ae11badd3345.png)

![image](https://user-images.githubusercontent.com/44526455/94954591-f5665880-0506-11eb-8a1c-d28e83d2f86f.png)

![image](https://user-images.githubusercontent.com/44526455/94954841-4aa26a00-0507-11eb-9491-1709287f1f3a.png)

