### PR TITLE
Fixed issues with text being invisible under bright backgrounds

### DIFF
--- a/src/display/general/init.go
+++ b/src/display/general/init.go
@@ -81,17 +81,19 @@ func (page *MainPage) InitGeneral(numCores int) {
 
 	// Initialize Bar Graph for Memory Chart
 	page.MemoryChart.Title = " Memory (RAM) "
+	page.MemoryChart.TitleStyle = ui.NewStyle(ui.ColorClear)
 	page.MemoryChart.Labels = []string{"Total", "Available", "Used", "Free"}
 	page.MemoryChart.BarWidth = 8
 	page.MemoryChart.BarGap = 9
 	page.MemoryChart.BarColors = []ui.Color{ui.ColorCyan, ui.ColorGreen}
-	page.MemoryChart.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorWhite)}
+	page.MemoryChart.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorClear)}
 	page.MemoryChart.NumStyles = []ui.Style{ui.NewStyle(ui.ColorBlack)}
 	page.MemoryChart.BorderStyle.Fg = ui.ColorCyan
 
 	// Initialize Table for Disk Chart
 	page.DiskChart.Title = " Disk "
-	page.DiskChart.TextStyle = ui.NewStyle(ui.ColorWhite)
+	page.DiskChart.TitleStyle = ui.NewStyle(ui.ColorClear)
+	page.DiskChart.TextStyle = ui.NewStyle(ui.ColorClear)
 	page.DiskChart.TextAlignment = ui.AlignLeft
 	page.DiskChart.RowSeparator = false
 	page.DiskChart.ColumnWidths = []int{9, 9, 9, 9, 9, 11}
@@ -99,6 +101,7 @@ func (page *MainPage) InitGeneral(numCores int) {
 
 	// Initialize Plot for Network Chart
 	page.NetworkChart.Title = " Network data(in mB) "
+	page.NetworkChart.TitleStyle = ui.NewStyle(ui.ColorClear)
 	page.NetworkChart.HorizontalScale = 1
 	page.NetworkChart.AxesColor = ui.ColorCyan
 	page.NetworkChart.LineColors[0] = ui.ColorRed
@@ -109,9 +112,11 @@ func (page *MainPage) InitGeneral(numCores int) {
 
 	// Initialize paragraph for NetPara
 	page.NetPara.Text = "[Total RX](fg:red): 0\n\n[Total TX](fg:green): 0"
+	page.NetPara.TextStyle = ui.NewStyle(ui.ColorClear)
 	page.NetPara.Border = true
 	page.NetPara.BorderStyle.Fg = ui.ColorCyan
 	page.NetPara.Title = " RX/TX "
+	page.NetPara.TitleStyle = ui.NewStyle(ui.ColorClear)
 
 	// Initialize Gauges for each CPU Core usage
 	for i := 0; i < numCores; i++ {
@@ -120,7 +125,8 @@ func (page *MainPage) InitGeneral(numCores int) {
 		tempGauge.Percent = 0
 		tempGauge.BarColor = ui.ColorBlue
 		tempGauge.BorderStyle.Fg = ui.ColorCyan
-		tempGauge.TitleStyle.Fg = ui.ColorWhite
+		tempGauge.TitleStyle.Fg = ui.ColorClear
+		tempGauge.LabelStyle.Fg = ui.ColorClear
 		page.CPUCharts = append(page.CPUCharts, tempGauge)
 	}
 
@@ -144,52 +150,62 @@ func (page *CPUPage) InitCPU(numCores int) {
 	page.UsrChart.Percent = 0
 	page.UsrChart.BarColor = ui.ColorBlue
 	page.UsrChart.BorderStyle.Fg = ui.ColorCyan
-	page.UsrChart.TitleStyle.Fg = ui.ColorWhite
+	page.UsrChart.TitleStyle.Fg = ui.ColorClear
+	page.UsrChart.LabelStyle.Fg = ui.ColorClear
 
 	page.NiceChart.Title = " Nice "
 	page.NiceChart.Percent = 0
 	page.NiceChart.BarColor = ui.ColorBlue
 	page.NiceChart.BorderStyle.Fg = ui.ColorCyan
-	page.NiceChart.TitleStyle.Fg = ui.ColorWhite
+	page.NiceChart.TitleStyle.Fg = ui.ColorClear
+	page.NiceChart.LabelStyle.Fg = ui.ColorClear
 
 	page.SysChart.Title = " Sys "
 	page.SysChart.Percent = 0
 	page.SysChart.BarColor = ui.ColorBlue
 	page.SysChart.BorderStyle.Fg = ui.ColorCyan
-	page.SysChart.TitleStyle.Fg = ui.ColorWhite
+	page.SysChart.TitleStyle.Fg = ui.ColorClear
+	page.SysChart.LabelStyle.Fg = ui.ColorClear
 
 	page.IowaitChart.Title = " Iowait "
 	page.IowaitChart.Percent = 0
 	page.IowaitChart.BarColor = ui.ColorBlue
 	page.IowaitChart.BorderStyle.Fg = ui.ColorCyan
-	page.IowaitChart.TitleStyle.Fg = ui.ColorWhite
+	page.IowaitChart.TitleStyle.Fg = ui.ColorClear
+	page.IowaitChart.LabelStyle.Fg = ui.ColorClear
 
 	page.IrqChart.Title = " Irq "
 	page.IrqChart.Percent = 0
 	page.IrqChart.BarColor = ui.ColorBlue
 	page.IrqChart.BorderStyle.Fg = ui.ColorCyan
-	page.IrqChart.TitleStyle.Fg = ui.ColorWhite
+	page.IrqChart.TitleStyle.Fg = ui.ColorClear
+	page.IrqChart.LabelStyle.Fg = ui.ColorClear
 
 	page.SoftChart.Title = " Soft "
 	page.SoftChart.Percent = 0
 	page.SoftChart.BarColor = ui.ColorBlue
 	page.SoftChart.BorderStyle.Fg = ui.ColorCyan
-	page.SoftChart.TitleStyle.Fg = ui.ColorWhite
+	page.SoftChart.TitleStyle.Fg = ui.ColorClear
+	page.SoftChart.LabelStyle.Fg = ui.ColorClear
 
 	page.IdleChart.Title = " Idle "
 	page.IdleChart.Percent = 0
 	page.IdleChart.BarColor = ui.ColorBlue
 	page.IdleChart.BorderStyle.Fg = ui.ColorCyan
-	page.IdleChart.TitleStyle.Fg = ui.ColorWhite
+	page.IdleChart.TitleStyle.Fg = ui.ColorClear
+	page.IdleChart.LabelStyle.Fg = ui.ColorClear
 
 	page.StealChart.Title = " Steal "
 	page.StealChart.Percent = 0
 	page.StealChart.BarColor = ui.ColorBlue
 	page.StealChart.BorderStyle.Fg = ui.ColorCyan
-	page.StealChart.TitleStyle.Fg = ui.ColorWhite
+	page.StealChart.TitleStyle.Fg = ui.ColorClear
+	page.StealChart.LabelStyle.Fg = ui.ColorClear
 
 	page.CPUChart.Title = " CPU "
-	page.CPUChart.TextStyle = ui.NewStyle(ui.ColorWhite)
+	page.CPUChart.TitleStyle = ui.NewStyle(ui.ColorClear)
+	page.CPUChart.BorderStyle = ui.NewStyle(ui.ColorCyan)
+	page.CPUChart.TextStyle = ui.NewStyle(ui.ColorClear)
 	page.CPUChart.TextAlignment = ui.AlignCenter
 	page.CPUChart.RowSeparator = true
 

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -54,38 +54,41 @@ func NewPerProcPage() *PerProcPage {
 func (page *PerProcPage) InitPerProc() {
 	// Initialize Gauge for CPU Chart
 	page.CPUChart.Title = " CPU % "
+	page.CPUChart.LabelStyle.Fg = ui.ColorClear
 	page.CPUChart.BarColor = ui.ColorGreen
 	page.CPUChart.BorderStyle.Fg = ui.ColorCyan
-	page.CPUChart.TitleStyle.Fg = ui.ColorWhite
+	page.CPUChart.TitleStyle.Fg = ui.ColorClear
 
 	// Initialize Gauge for Memory Chart
 	page.MemChart.Title = " Mem % "
+	page.MemChart.LabelStyle.Fg = ui.ColorClear
 	page.MemChart.BarColor = ui.ColorGreen
 	page.MemChart.BorderStyle.Fg = ui.ColorCyan
-	page.MemChart.TitleStyle.Fg = ui.ColorWhite
+	page.MemChart.TitleStyle.Fg = ui.ColorClear
 
 	// Initialize Table for PID Details Table
-	page.PIDTable.TextStyle = ui.NewStyle(ui.ColorWhite)
+	page.PIDTable.TextStyle = ui.NewStyle(ui.ColorClear)
 	page.PIDTable.TextAlignment = ui.AlignCenter
 	page.PIDTable.RowSeparator = false
 	page.PIDTable.Title = " PID "
 	page.PIDTable.BorderStyle.Fg = ui.ColorCyan
-	page.PIDTable.TitleStyle.Fg = ui.ColorWhite
+	page.PIDTable.TitleStyle.Fg = ui.ColorClear
 
 	// Initialize List for Child Processes list
 	page.ChildProcsList.Title = " Child Processes "
 	page.ChildProcsList.BorderStyle.Fg = ui.ColorCyan
-	page.ChildProcsList.TitleStyle.Fg = ui.ColorWhite
+	page.ChildProcsList.TitleStyle.Fg = ui.ColorClear
+	page.ChildProcsList.TextStyle.Fg = ui.ColorClear
 
 	// Initialize Bar Chart for CTX Swicthes Chart
 	page.CTXSwitchesChart.Data = []float64{0, 0}
 	page.CTXSwitchesChart.Labels = []string{"Volun", "Involun"}
 	page.CTXSwitchesChart.Title = " Ctx switches "
 	page.CTXSwitchesChart.BorderStyle.Fg = ui.ColorCyan
-	page.CTXSwitchesChart.TitleStyle.Fg = ui.ColorWhite
+	page.CTXSwitchesChart.TitleStyle.Fg = ui.ColorClear
 	page.CTXSwitchesChart.BarWidth = 9
 	page.CTXSwitchesChart.BarColors = []ui.Color{ui.ColorGreen, ui.ColorCyan}
-	page.CTXSwitchesChart.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorWhite)}
+	page.CTXSwitchesChart.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorClear)}
 	page.CTXSwitchesChart.NumStyles = []ui.Style{ui.NewStyle(ui.ColorBlack)}
 
 	// Initialize Bar Chart for Page Faults Chart
@@ -93,10 +96,10 @@ func (page *PerProcPage) InitPerProc() {
 	page.PageFaultsChart.Labels = []string{"minr", "mjr"}
 	page.PageFaultsChart.Title = " Page Faults "
 	page.PageFaultsChart.BorderStyle.Fg = ui.ColorCyan
-	page.PageFaultsChart.TitleStyle.Fg = ui.ColorWhite
+	page.PageFaultsChart.TitleStyle.Fg = ui.ColorClear
 	page.PageFaultsChart.BarWidth = 9
 	page.PageFaultsChart.BarColors = []ui.Color{ui.ColorGreen, ui.ColorCyan}
-	page.PageFaultsChart.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorWhite)}
+	page.PageFaultsChart.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorClear)}
 	page.PageFaultsChart.NumStyles = []ui.Style{ui.NewStyle(ui.ColorBlack)}
 
 	// Initialize Bar Chart for Memory Stats Chart
@@ -104,10 +107,10 @@ func (page *PerProcPage) InitPerProc() {
 	page.MemStatsChart.Labels = []string{"RSS", "Data", "Stack", "Swap"}
 	page.MemStatsChart.Title = " Mem Stats (mb) "
 	page.MemStatsChart.BorderStyle.Fg = ui.ColorCyan
-	page.MemStatsChart.TitleStyle.Fg = ui.ColorWhite
+	page.MemStatsChart.TitleStyle.Fg = ui.ColorClear
 	page.MemStatsChart.BarWidth = 9
 	page.MemStatsChart.BarColors = []ui.Color{ui.ColorGreen, ui.ColorMagenta, ui.ColorYellow, ui.ColorCyan}
-	page.MemStatsChart.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorWhite)}
+	page.MemStatsChart.LabelStyles = []ui.Style{ui.NewStyle(ui.ColorClear)}
 	page.MemStatsChart.NumStyles = []ui.Style{ui.NewStyle(ui.ColorBlack)}
 
 	// Initialize Grid layout
@@ -151,7 +154,7 @@ func NewAllProcsPage() *AllProcPage {
 
 // InitAllProc initializes and sets the ui and grid for grofer proc
 func (page *AllProcPage) InitAllProc() {
-	page.HeadingTable.TextStyle = ui.NewStyle(ui.ColorWhite)
+	page.HeadingTable.TextStyle = ui.NewStyle(ui.ColorClear)
 	page.HeadingTable.Rows = [][]string{[]string{" PID",
 		" Command",
 		" CPU",
@@ -165,7 +168,7 @@ func (page *AllProcPage) InitAllProc() {
 	page.HeadingTable.TextAlignment = ui.AlignLeft
 	page.HeadingTable.RowSeparator = false
 
-	page.BodyList.TextStyle = ui.NewStyle(ui.ColorWhite)
+	page.BodyList.TextStyle = ui.NewStyle(ui.ColorClear)
 	page.BodyList.TitleStyle.Fg = ui.ColorCyan
 
 	page.Grid.Set(


### PR DESCRIPTION
termui defaults to ColorWhite, which displays white text irrespective of terminal. Using ColorClear instead uses the default text color that the terminal uses.

ISSUES: Plot widget does not accept changes to the color of the axes for some reason, hence it remains grey under both Dark and Light-colored backgrounds.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #66 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible.
- [ ] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [X] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings 
- [X] Any dependent and pending changes have been merged and published
