### PR TITLE
Memory buffering to reduce disk IO and optimize intermediate memory usage

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	defaultExportRefreshRate = 1000
-	defaultExportIterations  = 10
-	defaultExportFileName    = "grofer_profile"
-	defaultExportType        = "json"
+	defaultExportRefreshRate    = 1000
+	defaultExportIterations     = 10
+	defaultExportBufferFraction = 0.5
+	defaultExportFileName       = "grofer_profile"
+	defaultExportType           = "json"
 )
 
 // Maintain a map of extensions provided by grofer.
@@ -105,9 +106,17 @@ var exportCmd = &cobra.Command{
 			return err
 		}
 
+		bufferFraction, err := cmd.Flags().GetFloat32("bufferFraction")
+		if err != nil {
+			return err
+		}
+		if bufferFraction < 0.0 {
+			return fmt.Errorf("bufferFraction cannot be negative")
+		}
+
 		switch exportType {
 		case "json":
-			return export.ExportJSON(fileName, iter, refreshRate)
+			return export.ExportJSON(fileName, iter, refreshRate, bufferFraction)
 		// TODO: add csv export functionality
 		default:
 			return fmt.Errorf("invalid export type, see grofer export --help")
@@ -142,5 +151,11 @@ func init() {
 		"t",
 		defaultExportType,
 		"specify the output format of the profiling result (json or csv)",
+	)
+	exportCmd.Flags().Float32P(
+		"bufferFraction",
+		"b",
+		defaultExportBufferFraction,
+		"fraction of the total output to be buffered in memory before making an I/O to export file",
 	)
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -92,7 +92,7 @@ var exportCmd = &cobra.Command{
 			return err
 		}
 		exportType = strings.ToLower(exportType)
-		if _, supported := providedExportTypes[exportType]; !supported {
+		if validExportType := providedExportTypes[exportType]; !validExportType {
 			return fmt.Errorf("export type not supported")
 		}
 

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -83,6 +83,9 @@ var exportCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if iter <= 0 {
+			return fmt.Errorf("no. of iterations should be positive")
+		}
 
 		refreshRate, err := cmd.Flags().GetUint64("refresh")
 		if err != nil {

--- a/src/export/general/export.go
+++ b/src/export/general/export.go
@@ -170,6 +170,7 @@ func getJSONData(iter uint32, refreshRate uint64, exportChan chan OverallStats, 
 		err := stats.updateData()
 		if err != nil {
 			exit.err = err
+			exit.finished = true
 			done <- exit
 			break
 		}

--- a/src/export/general/export.go
+++ b/src/export/general/export.go
@@ -175,7 +175,6 @@ func getJSONData(iter uint32, refreshRate uint64, exportChan chan OverallStats, 
 		}
 		exportChan <- *stats
 		done <- exit
-		fmt.Println(len(exportChan))
 		time.Sleep(time.Duration(refreshRate) * time.Millisecond)
 	}
 	exit.finished = true


### PR DESCRIPTION
# Description
- Instead of storing the entire export profile array in memory, added "periodic" appends to export file.
- Periodic meaning the output of a certain number of iterations will be buffered in memory before being written to file.
- Export is not done every iteration as that would increase I/O overhead for large values of `iter`. 
- Buffering and error handling is done using buffered channels.
- The fraction of the total output to be buffered in memory is also added as a flag to the `export` command. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
