### PR TITLE
GH-75: using after channel instead of delay so exit is immediate

### DIFF
--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -72,7 +72,7 @@ Syntax:
 			}
 
 			eg.Go(func() error {
-				return process.Serve(proc, dataChannel, ctx, int32(4*procRefreshRate/5))
+				return process.Serve(proc, dataChannel, ctx, int64(4*procRefreshRate/5))
 			})
 			eg.Go(func() error {
 				return procGraph.ProcVisuals(ctx, dataChannel, procRefreshRate)
@@ -89,7 +89,7 @@ Syntax:
 			eg, ctx := errgroup.WithContext(context.Background())
 
 			eg.Go(func() error {
-				return process.ServeProcs(dataChannel, ctx, int32(4*procRefreshRate/5))
+				return process.ServeProcs(dataChannel, ctx, int64(4*procRefreshRate/5))
 			})
 			eg.Go(func() error {
 				return procGraph.AllProcVisuals(dataChannel, ctx, procRefreshRate)

--- a/src/display/general/overallGraphs.go
+++ b/src/display/general/overallGraphs.go
@@ -232,6 +232,7 @@ func RenderCPUinfo(ctx context.Context,
 
 	var on sync.Once
 	var help *h.HelpMenu = h.NewHelpMenu()
+	h.SelectHelpMenu("main")
 
 	if err := ui.Init(); err != nil {
 		return fmt.Errorf("failed to initialize termui: %v", err)
@@ -251,6 +252,7 @@ func RenderCPUinfo(ctx context.Context,
 		myPage.Grid.SetRect(0, 0, w, h)
 		help.Resize(w, h)
 		if helpVisible {
+			ui.Clear()
 			ui.Render(help)
 		} else {
 			ui.Render(myPage.Grid)

--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -203,6 +203,7 @@ func ProcVisuals(ctx context.Context,
 					[]string{"[Nice value](fg:yellow)", strconv.Itoa(int(data.Nice))},
 					[]string{"[Thread count](fg:yellow)", strconv.Itoa(int(data.NumThreads))},
 					[]string{"[Child process count](fg:yellow)", strconv.Itoa(len(data.Children))},
+					[]string{"[Last Update](fg:yellow)", time.Now().Format("15:04:05")},
 				}
 				myPage.PIDTable.Title = " PID: " + strconv.Itoa(int(data.Proc.Pid)) + " "
 

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -93,17 +93,17 @@ func GetCPULoad(ctx context.Context,
 	dataChannel chan *CPULoad,
 	refreshRate uint64) error {
 	for {
+		err := cpuLoad.updateCPULoad()
+		if err != nil {
+			return err
+		}
+		dataChannel <- cpuLoad
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-
-		default: // Get Memory and CPU rates per core periodically
-			err := cpuLoad.updateCPULoad()
-			if err != nil {
-				return err
-			}
-			dataChannel <- cpuLoad
-			time.Sleep(time.Duration(refreshRate) * time.Millisecond)
+		case <-time.After(time.Duration(refreshRate) * time.Millisecond):
+			break
 		}
 	}
 }

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strconv"
-	"time"
 
+	"github.com/pesos/grofer/src/utils"
 	gjson "github.com/tidwall/gjson"
 )
 
@@ -88,22 +88,14 @@ func (c *CPULoad) updateCPULoad() error {
 }
 
 // GetCPULoad updated the CPULoad struct and serves the data to the data channel.
-func GetCPULoad(ctx context.Context,
-	cpuLoad *CPULoad,
-	dataChannel chan *CPULoad,
-	refreshRate uint64) error {
-	for {
+func GetCPULoad(ctx context.Context, cpuLoad *CPULoad, dataChannel chan *CPULoad, refreshRate uint64) error {
+	return utils.TickUntilDone(ctx, int64(refreshRate), func() error {
 		err := cpuLoad.updateCPULoad()
 		if err != nil {
 			return err
 		}
 		dataChannel <- cpuLoad
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(time.Duration(refreshRate) * time.Millisecond):
-			break
-		}
-	}
+		return nil
+	})
 }

--- a/src/general/generalStats.go
+++ b/src/general/generalStats.go
@@ -18,7 +18,6 @@ package general
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/pesos/grofer/src/utils"
 )
@@ -26,9 +25,7 @@ import (
 type serveFunc func(context.Context, chan utils.DataStats) error
 
 // GlobalStats gets stats about the mem and the CPUs and prints it.
-func GlobalStats(ctx context.Context,
-	dataChannel chan utils.DataStats,
-	refreshRate uint64) error {
+func GlobalStats(ctx context.Context, dataChannel chan utils.DataStats, refreshRate uint64) error {
 
 	serveFuncs := []serveFunc{
 		ServeCPURates,
@@ -37,8 +34,7 @@ func GlobalStats(ctx context.Context,
 		ServeNetRates,
 	}
 
-	for {
-		// Get Memory and CPU rates per core periodically
+	return utils.TickUntilDone(ctx, int64(refreshRate), func() error {
 		var wg sync.WaitGroup
 
 		errCh := make(chan error, len(serveFuncs))
@@ -59,11 +55,6 @@ func GlobalStats(ctx context.Context,
 			}
 		}
 
-		select {
-		case <-time.After(time.Duration(refreshRate) * time.Millisecond):
-			break
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
+		return nil
+	})
 }

--- a/src/general/generalStats.go
+++ b/src/general/generalStats.go
@@ -64,7 +64,12 @@ func GlobalStats(ctx context.Context,
 				}
 			}
 
-			time.Sleep(time.Duration(refreshRate) * time.Millisecond)
+			select {
+			case <-time.After(time.Duration(refreshRate) * time.Millisecond):
+				break
+			case <-ctx.Done():
+				return ctx.Err()
+			}
 		}
 	}
 }

--- a/src/process/serveData.go
+++ b/src/process/serveData.go
@@ -17,39 +17,28 @@ package process
 
 import (
 	"context"
-	"time"
 
+	"github.com/pesos/grofer/src/utils"
 	proc "github.com/shirou/gopsutil/process"
 )
 
 // Serve serves data on a per process basis
-func Serve(process *Process, dataChannel chan *Process, ctx context.Context, refreshRate int32) error {
-	for {
+func Serve(process *Process, dataChannel chan *Process, ctx context.Context, refreshRate int64) error {
+	return utils.TickUntilDone(ctx, refreshRate, func() error {
 		process.UpdateProcInfo()
 		dataChannel <- process
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(time.Duration(refreshRate) * time.Millisecond):
-			break
-		}
-	}
-
+		return nil
+	})
 }
 
-func ServeProcs(dataChannel chan []*proc.Process, ctx context.Context, refreshRate int32) error {
-	for {
+func ServeProcs(dataChannel chan []*proc.Process, ctx context.Context, refreshRate int64) error {
+	return utils.TickUntilDone(ctx, refreshRate, func() error {
 		procs, err := proc.Processes()
 		if err == nil {
 			dataChannel <- procs
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err() // Stop execution if end signal received
-		case <-time.After(time.Duration(refreshRate) * time.Millisecond):
-			break
-		}
-	}
+		return nil
+	})
 }

--- a/src/utils/tickutils.go
+++ b/src/utils/tickutils.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2020 The PES Open Source Team pesos@pes.edu
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (

--- a/src/utils/tickutils.go
+++ b/src/utils/tickutils.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"context"
+	"time"
+)
+
+func TickUntilDone(ctx context.Context, refreshRate int64, action func() error) error {
+	ticker := time.NewTicker(time.Duration(refreshRate) * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		err := action()
+		if err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err() // Stop execution if end signal received
+		case <-ticker.C:
+			break
+		}
+	}
+}


### PR DESCRIPTION
# Description

Using `time.After` channel instead of delay so that exit is immediate when application stops.

Fixes # GH-75

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
