### PR TITLE
Show correct error messages on negative pids (#86)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ This lists all running processes and relevant information.
 
 This gives information specific to a process, specified by a valid PID.
 
+Passing a PID of 0 will list all the processes instead (same as `grofer proc`).
+
 ![grofer-proc-pid](images/README/grofer-proc-pid.png)
 
 Information provided:  

--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	defaultProcRefreshRate = 3000
-	defaultProcPid         = -1
+	defaultProcPid         = 0
 )
 
 // procCmd represents the proc command

--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -120,6 +120,6 @@ func init() {
 		"pid",
 		"p",
 		defaultProcPid,
-		"specify pid of process",
+		"specify PID of process. Passing PID 0 lists all the processes (same as not using the -p flag).",
 	)
 }


### PR DESCRIPTION
# Description

Sets the default PID to 0, this ensures that the correct error message is shown when a negative PID is given. When PID 0 is given (`grofer proc -p 0`) it is considered to be the same as `grofer proc` i.e., all running processes are shown.

I'm not sure if this should be added to the README documentation, I can do this if needed.

WARNING: huge changes, might take a while to review :stuck_out_tongue_closed_eyes: 

Fixes #86 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
