### PR TITLE
Optimize struct memory usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
     docker:
       # specify the version
       - image: circleci/golang:1.14
+        environment:
+          GO111MODULE: "on"
 
     working_directory: /go/src/github.com/pesos/grofer
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,19 +4,15 @@ jobs:
     docker:
       # specify the version
       - image: circleci/golang:1.14
-        environment:
-          GO111MODULE: "on"
 
     working_directory: /go/src/github.com/pesos/grofer
     steps:
       - checkout
 
       # specify any bash command here prefixed with `run: `
+      - run: go get -v
+      - run: bash ./scripts/fmt.sh
+      - run: bash ./scripts/build.sh
       - run: sudo apt install python3 -y
       - run: python3 ./scripts/license_check.py
-      - run: go get -v
-      - run: go get golang.org/x/tools/go/analysis/passes/fieldalignment
-      - run: bash ./scripts/fmt.sh
-      - run: bash ./scripts/field_align_check.sh
-      - run: bash ./scripts/build.sh
       - run: go test -v -race $(go list ./src/utils | grep -v vendor)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,3 @@
-# Golang CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
   build:
@@ -13,9 +10,11 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
-      - run: go get -v
-      - run: bash ./scripts/fmt.sh
-      - run: bash ./scripts/build.sh
       - run: sudo apt install python3 -y
       - run: python3 ./scripts/license_check.py
+      - run: go get -v
+      - run: go get golang.org/x/tools/go/analysis/passes/fieldalignment
+      - run: bash ./scripts/fmt.sh
+      - run: bash ./scripts/field_align_check.sh
+      - run: bash ./scripts/build.sh
       - run: go test -v -race $(go list ./src/utils | grep -v vendor)

--- a/scripts/field_align_check.sh
+++ b/scripts/field_align_check.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright © 2020 The PES Open Source Team pesos@pes.edu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check if fields of structs in go files are ordered to take up the 
+# least space possible. 
+
+function not_aligned() {
+  echo -e "\nHmmm, it looks the fields of certain structs can be re-ordered\n"
+  echo -e "You can use the \`fieldalignment\` tool to apply the recommended reordering as follows:\n"
+  echo -e "\tIntsallation: go get golang.org/x/tools/go/analysis/passes/fieldalignment\n"
+  echo -e "\tUsage: fieldalignment -fix /path/to/file/having/struct"
+}
+
+if ! fieldalignment ./... ; then
+  not_aligned
+  exit 1
+fi

--- a/scripts/field_align_check.sh
+++ b/scripts/field_align_check.sh
@@ -20,9 +20,18 @@
 function not_aligned() {
   echo -e "\nHmmm, it looks the fields of certain structs can be re-ordered\n"
   echo -e "You can use the \`fieldalignment\` tool to apply the recommended reordering as follows:\n"
-  echo -e "\tIntsallation: go get golang.org/x/tools/go/analysis/passes/fieldalignment\n"
   echo -e "\tUsage: fieldalignment -fix /path/to/file/having/struct"
 }
+
+function command_not_found() {
+  echo -e "The command fieldalignment doesn't seem to be installed.\n"
+  echo -e "\tIntsallation: go get golang.org/x/tools/go/analysis/passes/fieldalignment\n"
+}
+
+if ! type fieldalignment &> /dev/null; then
+  command_not_found
+  exit 1
+fi
 
 if ! fieldalignment ./... ; then
   not_aligned

--- a/src/display/general/init.go
+++ b/src/display/general/init.go
@@ -28,8 +28,8 @@ type MainPage struct {
 	MemoryChart  *widgets.BarChart
 	DiskChart    *widgets.Table
 	NetworkChart *widgets.Plot
-	CPUCharts    []*widgets.Gauge
 	NetPara      *widgets.Paragraph
+	CPUCharts    []*widgets.Gauge
 }
 
 type CPUPage struct {

--- a/src/export/general/generalExport.go
+++ b/src/export/general/generalExport.go
@@ -55,9 +55,9 @@ type memStats struct {
 // OverallStats describes the structure of each exported json object.
 type OverallStats struct {
 	NetStats  map[string]netStats `json:"net"`
-	CpuLoad   cpuInfo.CPULoad     `json:"cpuLoad"`
 	CpuStats  []float64           `json:"cpu"`
 	DiskStats []diskStats         `json:"disk"`
+	CpuLoad   cpuInfo.CPULoad     `json:"cpuLoad"`
 	MemStats  memStats            `json:"mem"`
 	Epoch     uint64              `json:"epoch"`
 }

--- a/src/export/general/generalExport.go
+++ b/src/export/general/generalExport.go
@@ -33,11 +33,11 @@ import (
 
 type diskStats struct {
 	Path     string  `json:"path"`
+	Fs       string  `json:"fs"`
 	Total    float64 `json:"total"`
 	Used     float64 `json:"used"`
 	UsedPerc float64 `json:"usedPerc"`
 	Free     float64 `json:"free"`
-	Fs       string  `json:"fs"`
 }
 
 type netStats struct {
@@ -54,12 +54,12 @@ type memStats struct {
 
 // OverallStats describes the structure of each exported json object.
 type OverallStats struct {
-	Epoch     uint64              `json:"epoch"`
-	CpuStats  []float64           `json:"cpu"`
-	MemStats  memStats            `json:"mem"`
-	DiskStats []diskStats         `json:"disk"`
 	NetStats  map[string]netStats `json:"net"`
 	CpuLoad   cpuInfo.CPULoad     `json:"cpuLoad"`
+	CpuStats  []float64           `json:"cpu"`
+	DiskStats []diskStats         `json:"disk"`
+	MemStats  memStats            `json:"mem"`
+	Epoch     uint64              `json:"epoch"`
 }
 
 // NewOverallStats returns a pointer to an empty OverallStats struct
@@ -114,8 +114,7 @@ func (data *OverallStats) updateData() error {
 				usedPercent := utils.RoundFloat(usageVals.UsedPercent, "NONE", 2)
 				free := utils.RoundUint(usageVals.Free, "G", 2)
 				fs := usageVals.Fstype
-
-				temp := diskStats{path, total, used, usedPercent, free, fs}
+				temp := diskStats{path, fs, total, used, usedPercent, free}
 				tempParts = append(tempParts, temp)
 			}
 		}

--- a/src/export/proc/procExport.go
+++ b/src/export/proc/procExport.go
@@ -58,13 +58,13 @@ type ProcDetails struct {
 }
 
 type PidStats struct {
-	Cpu         float64         `json:"cpu"`
-	Mem         float64         `json:"mem"`
+	ChildProcs  map[int]string  `json:"childProcs"`
 	PidDetails  ProcDetails     `json:"pid"`
+	MemStats    memPidStats     `json:"memStats"`
 	CtxSwitches contextSwitches `json:"ctxSwitches"`
 	PageFaults  pageFaults      `json:"pageFaults"`
-	MemStats    memPidStats     `json:"memStats"`
-	ChildProcs  map[int]string  `json:"childProcs"`
+	Mem         float64         `json:"mem"`
+	Cpu         float64         `json:"cpu"`
 }
 
 var statusMap map[string]string = map[string]string{

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -29,17 +29,17 @@ import (
 // CPULoad type contains info about load on CPU from various sources
 // as well as general stats about the CPU.
 type CPULoad struct {
+	CPURates [][]string `json:"-"`
 	Usr      int        `json:"usr"`
 	Nice     int        `json:"nice"`
 	Sys      int        `json:"sys"`
 	Iowait   int        `json:"iowait"`
-	Irq      int        `json:"irq"`
 	Soft     int        `json:"soft"`
 	Steal    int        `json:"steal"`
 	Guest    int        `json:"guest"`
 	Gnice    int        `json:"gnice"`
 	Idle     int        `json:"idle"`
-	CPURates [][]string `json:"-"` // Has first row with CPU names and second row with CPU usage rates, might not be ideal format for export
+	Irq      int        `json:"irq"`
 }
 
 // NewCPULoad is a constructor for the CPULoad type.

--- a/src/process/process.go
+++ b/src/process/process.go
@@ -22,23 +22,23 @@ import (
 // Process type contains as fields all the information extracted from the kernel.
 type Process struct {
 	Proc           *proc.Process
-	Background     bool
-	Foreground     bool
-	IsRunning      bool
-	CPUPercent     float64
-	Children       []*proc.Process
-	CreateTime     int64
-	Gids           []int32
 	MemoryInfo     *proc.MemoryInfoStat
-	MemoryPercent  float32
-	Name           string
-	Nice           int32
-	NumCtxSwitches *proc.NumCtxSwitchesStat
-	NumThreads     int32
 	PageFault      *proc.PageFaultsStat
-	Status         string
+	NumCtxSwitches *proc.NumCtxSwitchesStat
 	Exe            string
+	Name           string
+	Status         string
+	Children       []*proc.Process
+	Gids           []int32
 	CPUAffinity    []int32
+	CreateTime     int64
+	CPUPercent     float64
+	Nice           int32
+	NumThreads     int32
+	MemoryPercent  float32
+	IsRunning      bool
+	Foreground     bool
+	Background     bool
 }
 
 // InitAllProcs initialises the set of currently running processes in the system.

--- a/src/utils/barGraph.go
+++ b/src/utils/barGraph.go
@@ -26,16 +26,16 @@ import (
 )
 
 type BarChart struct {
-	Block
+	NumFormatter func(float64) string
+	Labels       []string
 	BarColors    []Color
 	LabelStyles  []Style
-	NumStyles    []Style // only Fg and Modifier are used
-	NumFormatter func(float64) string
+	NumStyles    []Style
 	Data         []float64
-	Labels       []string
-	BarWidth     int
-	BarGap       int
-	MaxVal       float64
+	Block
+	BarWidth int
+	BarGap   int
+	MaxVal   float64
 }
 
 func NewBarChart() *BarChart {

--- a/src/utils/data.go
+++ b/src/utils/data.go
@@ -17,9 +17,9 @@ limitations under the License.
 package utils
 
 type DataStats struct {
+	NetStats  map[string][]float64
+	FieldSet  string
 	CpuStats  []float64
 	MemStats  []float64
 	DiskStats [][]string
-	NetStats  map[string][]float64
-	FieldSet  string
 }

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -25,29 +25,29 @@ import (
 
 func TestRoundValues(t *testing.T) {
 	tests := []struct {
+		expectedUnit        string
 		input               []float64
 		expectedRoundedVals []float64
-		expectedUnit        string
 	}{
 		{
-			[]float64{999, 895},
-			[]float64{999, 895},
 			" ",
+			[]float64{999, 895},
+			[]float64{999, 895},
 		},
 		{
+			" per thousand ",
 			[]float64{100000, 1000},
 			[]float64{100, 1},
-			" per thousand ",
 		},
 		{
+			" per million ",
 			[]float64{10000000, 1000},
 			[]float64{10, 0},
-			" per million ",
 		},
 		{
+			" per trillion ",
 			[]float64{100000000, 100000000000},
 			[]float64{0.1, 100},
-			" per trillion ",
 		},
 	}
 
@@ -90,13 +90,13 @@ func TestGetDateFromUnix(t *testing.T) {
 	date4 := t4.Format(time.RFC822)
 
 	tests := []struct {
-		inputVal    int64
 		expectedVal string
+		inputVal    int64
 	}{
-		{10000000, date1},
-		{0, date2},
-		{1596652055, date3},
-		{9999999999, date4},
+		{date1, 10000000},
+		{date2, 0},
+		{date3, 1596652055},
+		{date4, 9999999999},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Description

Ordering of fields in `struct`s can impact the consumption of memory due to Go trying to pad all fields according to the largest field in the struct. The [`fieldalignment`](https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/fieldalignment) tool is helpful in detecting and also helping with re-writing structs automatically if needed. 

Output after running `fieldalignment` on the existing codebase: 

```
grofer/src/utils/barGraph.go:28:15: struct with 296 pointer bytes could be 272
grofer/src/utils/data.go:19:16: struct with 88 pointer bytes could be 80
grofer/src/general/cpuInfo.go:31:14: struct with 88 pointer bytes could be 8
grofer/src/display/general/init.go:26:15: struct with 64 pointer bytes could be 48
grofer/src/process/process.go:23:14: struct of size 200 could be 184
grofer/src/export/general/generalExport.go:34:16: struct with 56 pointer bytes could be 24
grofer/src/export/general/generalExport.go:56:19: struct with 184 pointer bytes could be 144
grofer/src/export/general/generalExport.go:56:19: struct with 144 pointer bytes could be 64
grofer/src/export/proc/procExport.go:60:15: struct with 232 pointer bytes could be 144
grofer/src/utils/utils_test.go:27:13: struct with 56 pointer bytes could be 48
grofer/src/utils/utils_test.go:92:13: struct with 16 pointer bytes could be 8
```

- To check for field alignment `scripts/field_align_check.sh` can be run. This needs to be documented in CONTRIBUTING.md

## Caveats:
- If the `-fix` flag is used with the `fieldalignment` tool, then if structs are created in the code without qualifying the values with field names, the change in order can break the build. As a general practice, we can follow that all `struct` values be qualifies with field names to ensure that the order of the fields won't break code.
    - This can be a separate issue by itself.
- Sometimes, after applying the `-fix`, if `fieldalignment` is run again, it might come up with newer optimizations. 

These caveats need to be documented in CONTRIBUTING.md

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
