### PR TITLE
Fix incorrect timestamps

### DIFF
--- a/src/utils/dataFormat.go
+++ b/src/utils/dataFormat.go
@@ -100,7 +100,7 @@ func GetInMB(bytes uint64, precision int) float64 {
 
 // GetDateFromUnix gets a date and time in RFC822 format from a unix epoch
 func GetDateFromUnix(createTime int64) string {
-	t := time.Unix(createTime, 0)
+	t := time.Unix(createTime/1000, 0)
 	date := t.Format(time.RFC822)
 	return date
 }

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -122,10 +122,10 @@ func TestGetDateFromUnix(t *testing.T) {
 		expectedVal string
 		inputVal    int64
 	}{
-		{date1, 10000000},
+		{date1, 10000000000},
 		{date2, 0},
-		{date3, 1596652055},
-		{date4, 9999999999},
+		{date3, 1596652055000},
+		{date4, 9999999999000},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
# Fix incorrect timespamt in grofer proc

time.Unix expects the time to be in seconds whereas gopsutil gives time in milliseconds

Fixes #104 

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [ ] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [ ] Any dependent and pending changes have been merged and published
