### PR TITLE
Add Sort functionality to overall process and container tables

### DIFF
--- a/src/display/container/init.go
+++ b/src/display/container/init.go
@@ -98,7 +98,7 @@ func (page *OverallContainerPage) InitOverallContainer() {
 			10, 10, 17, 23,
 		}
 	}
-	page.DetailsTable.Header = []string{"ID", "Image", "Name", "Status", "State", "CPU", "Memory", "Net I/O", "Block I/O "}
+	page.DetailsTable.Header = []string{"ID", "Image", "Name", "Status", "State", "CPU", "Memory", "Net I/O", "Block I/O"}
 	page.DetailsTable.ShowCursor = true
 	page.DetailsTable.CursorColor = ui.ColorCyan
 

--- a/src/display/container/overallContainer.go
+++ b/src/display/container/overallContainer.go
@@ -100,34 +100,6 @@ func OverallVisuals(ctx context.Context, dataChannel chan container.ContainerMet
 		}
 	}
 
-	strSort := func(i, j int) bool {
-		if sortAsc {
-			return myPage.DetailsTable.Rows[i][sortIdx] < myPage.DetailsTable.Rows[j][sortIdx]
-		}
-		return myPage.DetailsTable.Rows[i][sortIdx] > myPage.DetailsTable.Rows[j][sortIdx]
-	}
-
-	floatSort := func(i, j int) bool {
-		x1 := myPage.DetailsTable.Rows[i][sortIdx]
-		y1 := myPage.DetailsTable.Rows[j][sortIdx]
-		x, _ := strconv.ParseFloat(x1[:len(x1)-1], 32)
-		y, _ := strconv.ParseFloat(y1[:len(y1)-1], 32)
-		if sortAsc {
-			return x < y
-		}
-		return x > y
-	}
-
-	sortFuncs := map[int]func(i, j int) bool{
-		0: strSort,
-		1: strSort,
-		2: strSort,
-		3: strSort,
-		4: strSort,
-		5: floatSort,
-		6: floatSort,
-	}
-
 	updateUI() // Initialize empty UI
 
 	uiEvents := ui.PollEvents()
@@ -196,7 +168,7 @@ func OverallVisuals(ctx context.Context, dataChannel chan container.ContainerMet
 					sortIdx = idx - 1
 					myPage.DetailsTable.Header[sortIdx] = header[sortIdx] + " " + UP_ARROW
 					sortAsc = true
-					sort.Slice(myPage.DetailsTable.Rows, sortFuncs[sortIdx])
+					utils.SortData(myPage.DetailsTable.Rows, sortIdx, sortAsc, "CONTAINER")
 
 				// Sort Descending
 				case "<F1>", "<F2>", "<F3>", "<F4>", "<F5>", "<F6>", "<F7>":
@@ -205,13 +177,12 @@ func OverallVisuals(ctx context.Context, dataChannel chan container.ContainerMet
 					sortIdx = idx - 1
 					myPage.DetailsTable.Header[sortIdx] = header[sortIdx] + " " + DOWN_ARROW
 					sortAsc = false
-					sort.Slice(myPage.DetailsTable.Rows, sortFuncs[sortIdx])
+					utils.SortData(myPage.DetailsTable.Rows, sortIdx, sortAsc, "CONTAINER")
 
 				// Disable Sort
 				case "0":
 					myPage.DetailsTable.Header = append([]string{}, header...)
 					sortIdx = -1
-
 				}
 
 				ui.Render(myPage.Grid)
@@ -265,6 +236,10 @@ func OverallVisuals(ctx context.Context, dataChannel chan container.ContainerMet
 				}
 
 				myPage.DetailsTable.Rows = containerData
+
+				if sortIdx != -1 {
+					utils.SortData(myPage.DetailsTable.Rows, sortIdx, sortAsc, "CONTAINER")
+				}
 
 				on.Do(updateUI)
 			}

--- a/src/display/misc/keybinds.go
+++ b/src/display/misc/keybinds.go
@@ -36,6 +36,7 @@ var PROC_KEYBINDS = []string{
 	"  - 0: Disable Sort",
 	"",
 	"[Process actions](fg:white)",
+	"[Requires confirmation, press key again to confirm](fg:white)",
 	"  - K and <F9>: Kill process",
 }
 

--- a/src/display/misc/keybinds.go
+++ b/src/display/misc/keybinds.go
@@ -19,7 +19,7 @@ package help
 var PROC_KEYBINDS = []string{
 	"Quit: q or <C-c>",
 	"",
-	"Process navigation:",
+	"[Process navigation](fg:white)",
 	"  - k and <Up>: up",
 	"  - j and <Down>: down",
 	"  - <C-u>: half page up",
@@ -29,14 +29,20 @@ var PROC_KEYBINDS = []string{
 	"  - gg and <Home>: jump to top",
 	"  - G and <End>: jump to bottom",
 	"",
-	"Process actions:",
+	"[Sorting](fg:white)",
+	"  - Use column number to sort ascending.",
+	"  - Use <F-column number> to sort descending.",
+	"  - Eg: 1 to sort ascedning on 1st Col and F1 for descending",
+	"  - 0: Disable Sort",
+	"",
+	"[Process actions](fg:white)",
 	"  - K and <F9>: Kill process",
 }
 
 var CONT_KEYBINDS = []string{
 	"Quit: q or <C-c>",
 	"",
-	"Container navigation:",
+	"[Container navigation](fg:white)",
 	"  - k and <Up>: up",
 	"  - j and <Down>: down",
 	"  - <C-u>: half page up",
@@ -46,21 +52,27 @@ var CONT_KEYBINDS = []string{
 	"  - gg and <Home>: jump to top",
 	"  - G and <End>: jump to bottom",
 	"",
-	"Container actions:",
-	"  - K and <F9>: Kill Container",
+	"[Sorting](fg:white)",
+	"  - Use column number to sort ascending.",
+	"  - Use <F-column number> to sort descending.",
+	"  - Eg: 1 to sort ascedning on 1st Col and F1 for descending",
+	"  - 0: Disable Sort",
+	// "",
+	// "[Container actions](fg:white)",
+	// "  - K and <F9>: Kill Container",
 }
 
 var CONT_CID_KEYBINDS = []string{
 	"Quit: q or <C-c>",
 	"",
-	"Table Selection",
+	"[Table Selection](fg:white)",
 	"  - 1: MountTable",
 	"  - 2: NetworkTable",
 	"  - 3: CPUUsageTable",
 	"  - 4: PortMapTable",
 	"  - 5: ProcTable",
 	"",
-	"Table navigation:",
+	"[Table navigation](fg:white)",
 	"  - k and <Up>: up",
 	"  - j and <Down>: down",
 	"  - <C-u>: half page up",
@@ -69,7 +81,6 @@ var CONT_CID_KEYBINDS = []string{
 	"  - <C-f>: full page down",
 	"  - gg and <Home>: jump to top",
 	"  - G and <End>: jump to bottom",
-	"",
 }
 
 var MAIN_KEYBINDS = []string{

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -145,44 +144,6 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 		runAllProc = !runAllProc
 	}
 
-	intSort := func(i, j int) bool {
-		x, _ := strconv.Atoi(myPage.ProcTable.Rows[i][sortIdx])
-		y, _ := strconv.Atoi(myPage.ProcTable.Rows[j][sortIdx])
-		if sortAsc {
-			return x < y
-		}
-		return x > y
-	}
-
-	strSort := func(i, j int) bool {
-		if sortAsc {
-			return myPage.ProcTable.Rows[i][sortIdx] < myPage.ProcTable.Rows[j][sortIdx]
-		}
-		return myPage.ProcTable.Rows[i][sortIdx] > myPage.ProcTable.Rows[j][sortIdx]
-	}
-
-	floatSort := func(i, j int) bool {
-		x1 := myPage.ProcTable.Rows[i][sortIdx]
-		y1 := myPage.ProcTable.Rows[j][sortIdx]
-		x, _ := strconv.ParseFloat(x1[:len(x1)-1], 32)
-		y, _ := strconv.ParseFloat(y1[:len(y1)-1], 32)
-		if sortAsc {
-			return x < y
-		}
-		return x > y
-	}
-
-	sortFuncs := map[int]func(i, j int) bool{
-		0: intSort,
-		1: strSort,
-		2: floatSort,
-		3: floatSort,
-		4: strSort,
-		5: strSort,
-		6: strSort,
-		7: intSort,
-	}
-
 	uiEvents := ui.PollEvents()
 	t := time.NewTicker(time.Duration(refreshRate) * time.Millisecond)
 	tick := t.C
@@ -283,7 +244,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 						sortIdx = idx - 1
 						myPage.ProcTable.Header[sortIdx] = header[sortIdx] + " " + UP_ARROW
 						sortAsc = true
-						sort.Slice(myPage.ProcTable.Rows, sortFuncs[sortIdx])
+						utils.SortData(myPage.ProcTable.Rows, sortIdx, sortAsc, "PROCS")
 
 					// Sort Descending
 					case "<F1>", "<F2>", "<F3>", "<F4>", "<F5>", "<F6>", "<F7>", "<F8>":
@@ -292,7 +253,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 						sortIdx = idx - 1
 						myPage.ProcTable.Header[sortIdx] = header[sortIdx] + " " + DOWN_ARROW
 						sortAsc = false
-						sort.Slice(myPage.ProcTable.Rows, sortFuncs[sortIdx])
+						utils.SortData(myPage.ProcTable.Rows, sortIdx, sortAsc, "PROCS")
 
 					// Disable Sort
 					case "0":
@@ -339,7 +300,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 				procData := getData(data)
 				myPage.ProcTable.Rows = procData
 				if sortIdx != -1 {
-					sort.Slice(myPage.ProcTable.Rows, sortFuncs[sortIdx])
+					utils.SortData(myPage.ProcTable.Rows, sortIdx, sortAsc, "PROCS")
 				}
 				on.Do(updateUI)
 			}

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -162,7 +162,8 @@ func NewAllProcsPage() *AllProcPage {
 
 // InitAllProc initializes and sets the ui and grid for grofer proc
 func (page *AllProcPage) InitAllProc() {
-	page.ProcTable.Header = []string{" PID",
+	page.ProcTable.Header = []string{
+		"PID",
 		"Command",
 		"CPU",
 		"Memory",

--- a/src/utils/sort.go
+++ b/src/utils/sort.go
@@ -21,7 +21,10 @@ import (
 	"strconv"
 )
 
-// SortData helps sort table rows. It sorts the table based on values given in the sortIdx column and sorts ascending if sortAsc is true. sortCase is set to identify the set of 'less' functions to use to sort the selected column by.
+// SortData helps sort table rows. It sorts the table based on values given
+// in the sortIdx column and sorts ascending if sortAsc is true.
+// sortCase is set to identify the set of 'less' functions to use to
+// sort the selected column by.
 func SortData(data [][]string, sortIdx int, sortAsc bool, sortCase string) {
 
 	// Define less functions
@@ -57,24 +60,24 @@ func SortData(data [][]string, sortIdx int, sortAsc bool, sortCase string) {
 	switch sortCase {
 	case "PROCS":
 		sortFuncs = map[int]func(i, j int) bool{
-			0: intSort,
-			1: strSort,
-			2: floatSort,
-			3: floatSort,
-			4: strSort,
-			5: strSort,
-			6: strSort,
-			7: intSort,
+			0: intSort,   // PID
+			1: strSort,   // Command
+			3: floatSort, // CPU %
+			2: floatSort, // Memory %
+			4: strSort,   // Status
+			5: strSort,   // Foreground
+			6: strSort,   // Creation Time
+			7: intSort,   // Thread Count
 		}
 	case "CONTAINER":
 		sortFuncs = map[int]func(i, j int) bool{
-			0: strSort,
-			1: strSort,
-			2: strSort,
-			3: strSort,
-			4: strSort,
-			5: floatSort,
-			6: floatSort,
+			0: strSort,   // ID
+			1: strSort,   // Image
+			2: strSort,   // Name
+			3: strSort,   // Status
+			4: strSort,   // State
+			5: floatSort, // CPU %
+			6: floatSort, // Memory %
 		}
 
 	default:

--- a/src/utils/sort.go
+++ b/src/utils/sort.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2020 The PES Open Source Team pesos@pes.edu
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"sort"
+	"strconv"
+)
+
+// SortData helps sort table rows. It sorts the table based on values given in the sortIdx column and sorts ascending if sortAsc is true. sortCase is set to identify the set of 'less' functions to use to sort the selected column by.
+func SortData(data [][]string, sortIdx int, sortAsc bool, sortCase string) {
+
+	// Define less functions
+	intSort := func(i, j int) bool {
+		x, _ := strconv.Atoi(data[i][sortIdx])
+		y, _ := strconv.Atoi(data[j][sortIdx])
+		if sortAsc {
+			return x < y
+		}
+		return x > y
+	}
+
+	strSort := func(i, j int) bool {
+		if sortAsc {
+			return data[i][sortIdx] < data[j][sortIdx]
+		}
+		return data[i][sortIdx] > data[j][sortIdx]
+	}
+
+	floatSort := func(i, j int) bool {
+		x1 := data[i][sortIdx]
+		y1 := data[j][sortIdx]
+		x, _ := strconv.ParseFloat(x1[:len(x1)-1], 32)
+		y, _ := strconv.ParseFloat(y1[:len(y1)-1], 32)
+		if sortAsc {
+			return x < y
+		}
+		return x > y
+	}
+
+	// Set function map
+	sortFuncs := make(map[int]func(i, j int) bool)
+	switch sortCase {
+	case "PROCS":
+		sortFuncs = map[int]func(i, j int) bool{
+			0: intSort,
+			1: strSort,
+			2: floatSort,
+			3: floatSort,
+			4: strSort,
+			5: strSort,
+			6: strSort,
+			7: intSort,
+		}
+	case "CONTAINER":
+		sortFuncs = map[int]func(i, j int) bool{
+			0: strSort,
+			1: strSort,
+			2: strSort,
+			3: strSort,
+			4: strSort,
+			5: floatSort,
+			6: floatSort,
+		}
+
+	default:
+		sortFuncs[sortIdx] = strSort
+	}
+
+	// Sort data
+	sort.Slice(data, sortFuncs[sortIdx])
+}

--- a/src/utils/sort_test.go
+++ b/src/utils/sort_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2020 The PES Open Source Team pesos@pes.edu
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils_test
 
 import (

--- a/src/utils/sort_test.go
+++ b/src/utils/sort_test.go
@@ -1,0 +1,50 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/pesos/grofer/src/utils"
+)
+
+func TestSortData(t *testing.T) {
+	tests := []struct {
+		inputVal    [][]string
+		sortIdx     int
+		sortAsc     bool
+		sortCase    string
+		expectedVal [][]string
+	}{
+		{
+			inputVal: [][]string{
+				{"CID1", "IMG1", "NAME1", "Up 5 Seconds", "Running", "12.34%", "4.20%"},
+				{"CID2", "IMG2", "NAME2", "Up 1 Second", "Running", "69.69%", "4.20%"},
+			},
+			sortIdx:  5,
+			sortAsc:  false,
+			sortCase: "CONT",
+			expectedVal: [][]string{
+				{"CID2", "IMG2", "NAME2", "Up 1 Second", "Running", "69.69%", "4.20%"},
+				{"CID1", "IMG1", "NAME1", "Up 5 Seconds", "Running", "12.34%", "4.20%"},
+			},
+		},
+		{
+			inputVal: [][]string{
+				{"CID1", "IMG1", "NAME1", "Up 5 Seconds", "Running", "12.34%", "4.20%"},
+				{"CID2", "IMG2", "NAME2", "Up 1 Second", "Running", "69.69%", "4.20%"},
+			},
+			sortIdx:  3,
+			sortAsc:  true,
+			sortCase: "",
+			expectedVal: [][]string{
+				{"CID2", "IMG2", "NAME2", "Up 1 Second", "Running", "69.69%", "4.20%"},
+				{"CID1", "IMG1", "NAME1", "Up 5 Seconds", "Running", "12.34%", "4.20%"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		utils.SortData(test.inputVal, test.sortIdx, test.sortAsc, test.sortCase)
+		utils.Equals(t, test.inputVal, test.expectedVal)
+	}
+
+}


### PR DESCRIPTION
# Description

- Add sort capabilities to proc table and container table. 
- Data can be sorted on column numbers. Eg: 1 to sort on first column in ascending order and F1, to sort in descending.
- `grofer proc` can be sorted on all 8 fields
- `grofer container` can be sorted on all fields except Net & Block I/O (Multiple values exist, unsure on how to sort).

Fixes #107 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published
