### PR TITLE
[WIP][FEATURE] Navigation to proc of child processes enabled

### DIFF
--- a/src/display/process/procGraphs.go
+++ b/src/display/process/procGraphs.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"log"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -164,12 +165,11 @@ func ProcVisuals(ctx context.Context,
 					myPage.ChildProcsTable.ScrollTop()
 				case "G", "<End>":
 					myPage.ChildProcsTable.ScrollBottom()
-					myPage.ChildProcsList.ScrollBottom()
 				case "<Enter>":
-					if myPage.ChildProcsList.SelectedRow != 0 {
-						row := myPage.ChildProcsList.Rows[myPage.ChildProcsList.SelectedRow]
+					if myPage.ChildProcsTable.SelectedRow != 0 {
+						row := myPage.ChildProcsTable.Rows[myPage.ChildProcsTable.SelectedRow]
 						// get PID from the data
-						pid, err := strconv.ParseInt(strings.SplitN(row, " ", 2)[0], 10, 32)
+						pid, err := strconv.ParseInt(strings.SplitN(row[0], " ", 2)[0], 10, 32)
 						if err != nil {
 							return fmt.Errorf("Failed to get PID of process: %v", err)
 						}
@@ -187,6 +187,7 @@ func ProcVisuals(ctx context.Context,
 								fmt.Printf("Error: %v\n", err)
 							}
 						}
+
 					}
 				}
 


### PR DESCRIPTION
# Description

Navigation to the child processes is enabled in the case of `grofer proc -p <pid>`. Keybinding used is `Enter`.

Fixes #100 

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings 
- [x] Any dependent and pending changes have been merged and published


# Additional Info
 - [ ] Causes Error when trying to exit with two or more child process navigation. Error might have occurred due to the recursive call in line [183](https://github.com/lucasace/grofer/blob/08ecd74fe86125a0e5018c5b9500118e928ad71e/src/display/process/procGraphs.go#L183)

![Screenshot from 2021-04-13 10-24-56](https://user-images.githubusercontent.com/54945757/118350052-41d04700-b572-11eb-81a1-2b390c7b5267.png)

- [ ] Need to enable the feature for allProcs.go i,e `grofer proc`