### PR TITLE
Remove `mpstat` as a dependency for the CPU Info page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 - Look for issues in the repository. Identify an issue you would like to work on.
 - Once you have done that, leave a comment on the issue saying that you want to work on it. The maintainers will give you the go-ahead.
-- Fork the repository. Your changes will be made on its `master` branch, or on the appropriate feature branch if applicable
+- Fork the repository. Your changes will be made on its `main` branch, or on the appropriate feature branch if applicable
 - Clone the fork on your system. Add a remote to the original `pesos/grofer` repository called `upstream`
 ```
 git clone https://github.com/<your-github-username>/grofer.git
@@ -18,7 +18,7 @@ git commit
 
 - Before pushing your changes, make sure that the changes from upstream are included (use `--rebase` to make sure that your changes stay on top of the latest changes in the upstream repository)
 ```
-git pull --rebase upstream main     # if you are working on a feature branch, use that branch name instead of master
+git pull --rebase upstream main     # if you are working on a feature branch, use that branch name instead of main
 ```
 
 - In the *extremely* small chance that you run into a conflict, just open the files having the conflict and remove the markers and edit the file to the one you want to push. After editing, run `git rebase --continue` and repeat till no conflict remains
@@ -26,16 +26,16 @@ git pull --rebase upstream main     # if you are working on a feature branch, us
 - Verify that your program builds and passes all the tests, and your change actually works in general
 - Push your changes to your fork
 ```
-git push origin main      # if you are working on a feature branch, use that branch name instead of master
+git push origin main      # if you are working on a feature branch, use that branch name instead of main
 ```
-- Visit your forked repository and click on "Pull Request". The Pull Request must always be made to the `pesos/master` branch. Add the relevant description. At this point your name will be assigned to the original issue.
+- Visit your forked repository and click on "Pull Request". The Pull Request must always be made to the `pesos/main` branch. Add the relevant description. At this point your name will be assigned to the original issue.
 - The maintainers will review your code and see if it is okay to merge. It is quite normal for them to suggest you to make some changes in this review.
 - if you are asked to make changes, all you need to do is:
 ```
 # make your change
 git add <files that you changed>
 git commit
-git push origin main      # if you are working on a feature branch, use that branch name instead of master
+git push origin main      # if you are working on a feature branch, use that branch name instead of main
 ```
 - The changes are immediately reflected in the pull request. Once the maintainers are satisfied, they will merge your contribution :)
 
@@ -45,6 +45,6 @@ As long as you follow the above instructions things should go well. You are alwa
 
 - main branch for development. Small patches/enhancements go here.
 - stable branch for tagged releases. This is the branch that will be shipped to users.
-- Separate feature-x branches for adding new "big" features. These branches are merged with master, on completion.
-- Once we are satisfied with a certain set of features and stability, we pull the changes from master to stable. A new release tag is made.
-- If bugs were found on the stable release, we create a hotfix branch and fix the bug. The master branch must also pull the changes from hotfix. A new release tag is created (incrementing with a smaller number).
+- Separate feature-x branches for adding new "big" features. These branches are merged with main, on completion.
+- Once we are satisfied with a certain set of features and stability, we pull the changes from main to stable. A new release tag is made.
+- If bugs were found on the stable release, we create a hotfix branch and fix the bug. The main branch must also pull the changes from hotfix. A new release tag is created (incrementing with a smaller number).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ git commit
 
 - Before pushing your changes, make sure that the changes from upstream are included (use `--rebase` to make sure that your changes stay on top of the latest changes in the upstream repository)
 ```
-git pull --rebase upstream master     # if you are working on a feature branch, use that branch name instead of master
+git pull --rebase upstream main     # if you are working on a feature branch, use that branch name instead of master
 ```
 
 - In the *extremely* small chance that you run into a conflict, just open the files having the conflict and remove the markers and edit the file to the one you want to push. After editing, run `git rebase --continue` and repeat till no conflict remains
@@ -26,7 +26,7 @@ git pull --rebase upstream master     # if you are working on a feature branch, 
 - Verify that your program builds and passes all the tests, and your change actually works in general
 - Push your changes to your fork
 ```
-git push origin master      # if you are working on a feature branch, use that branch name instead of master
+git push origin main      # if you are working on a feature branch, use that branch name instead of master
 ```
 - Visit your forked repository and click on "Pull Request". The Pull Request must always be made to the `pesos/master` branch. Add the relevant description. At this point your name will be assigned to the original issue.
 - The maintainers will review your code and see if it is okay to merge. It is quite normal for them to suggest you to make some changes in this review.
@@ -35,7 +35,7 @@ git push origin master      # if you are working on a feature branch, use that b
 # make your change
 git add <files that you changed>
 git commit
-git push origin master      # if you are working on a feature branch, use that branch name instead of master
+git push origin main      # if you are working on a feature branch, use that branch name instead of master
 ```
 - The changes are immediately reflected in the pull request. Once the maintainers are satisfied, they will merge your contribution :)
 
@@ -43,7 +43,7 @@ As long as you follow the above instructions things should go well. You are alwa
 
 ## Release overview (for the more regular contributors)
 
-- master branch for development. Small patches/enhancements go here.
+- main branch for development. Small patches/enhancements go here.
 - stable branch for tagged releases. This is the branch that will be shipped to users.
 - Separate feature-x branches for adding new "big" features. These branches are merged with master, on completion.
 - Once we are satisfied with a certain set of features and stability, we pull the changes from master to stable. A new release tag is made.

--- a/README.md
+++ b/README.md
@@ -22,11 +22,7 @@ As an executable:
 curl -sSL https://github.com/pesos/grofer/releases/download/<version tag>/grofer_<architecture> --output grofer
 chmod +x grofer
 ```
-`architecture`: underlying system architecture on which grofer will be run
-- grofer_386
-- grofer_amd64
-- grofer_arm
-- grofer_arm64
+Latest version: `v1.3.0`
 
 `architecture`: underlying system architecture on which grofer will be run  
  - grofer_386  

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/viper v1.7.1
-	github.com/tidwall/gjson v1.7.5
 	golang.org/x/net v0.0.0-20210505024714-0287a6fb4125 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -641,12 +641,6 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/tidwall/gjson v1.7.5 h1:zmAN/xmX7OtpAkv4Ovfso60r/BiCi5IErCDYGNJu+uc=
-github.com/tidwall/gjson v1.7.5/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
-github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
-github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
-github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -58,18 +58,16 @@ func readCPULoad(c *CPULoad) error {
 	// First line should store in the format:
 	// "cpu <usr> <nice> <system> <idle> <iowait> <irq> <softirq> <steal> <guest> <guest_nice>"
 	vals := strings.Fields(lines[0])
+	// Start from index 1 as first element is the cpu/cpu<no>
+	vals = vals[1:]
 	var avg [10]float64
 	sum := 0
 	for i, x := range vals {
-		// Start from index 1 as first element is the cpu/cpu<no>
-		if i < 1 {
-			continue
-		}
 		curr, err := strconv.Atoi(x)
 		if err != nil {
 			return error
 		} else {
-			avg[i-1] = float64(curr)
+			avg[i] = float64(curr)
 			sum += curr
 		}
 	}

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -57,19 +57,19 @@ func readCPULoad(c *CPULoad) error {
 	lines := strings.Split(stringData, "\n")
 	// First line should store in the format:
 	// "cpu <usr> <nice> <system> <idle> <iowait> <irq> <softirq> <steal> <guest> <guest_nice>"
-	vals := strings.Split(lines[0], " ")
+	vals := strings.Fields(lines[0])
 	var avg [10]float64
 	sum := 0
 	for i, x := range vals {
-		// Start from index 2 as there's an extra space (" ") on the first line of /proc/stat
-		if i < 2 {
+		// Start from index 1 as first element is the cpu/cpu<no>
+		if i < 1 {
 			continue
 		}
 		curr, err := strconv.Atoi(x)
 		if err != nil {
 			return error
 		} else {
-			avg[i-2] = float64(curr)
+			avg[i-1] = float64(curr)
 			sum += curr
 		}
 	}

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -66,21 +66,12 @@ func ReadCPULoad() ([10]float64, error) {
 		if err != nil {
 			return [10]float64{}, error
 		} else {
+			avg[i-2] = float64(curr)
 			sum += curr
 		}
 	}
-
-	for i, x := range vals {
-		if i < 2 {
-			continue
-		}
-		curr, err := strconv.Atoi(x)
-		if err != nil {
-			fmt.Print(err)
-			return [10]float64{}, err
-		} else {
-			avg[i-2] = 100 * float64(curr) / float64(sum)
-		}
+	for i, x := range avg {
+		avg[i] = 100 * x / float64(sum)
 	}
 	return avg, error
 }

--- a/src/general/cpuInfo.go
+++ b/src/general/cpuInfo.go
@@ -48,7 +48,7 @@ func NewCPULoad() *CPULoad {
 }
 
 // ReadCPULoad reads /proc/stat and returns the average load
-func readCPULoad(c *CPULoad) error {
+func (c *CPULoad) readCPULoad() error {
 	data, error := os.ReadFile("/proc/stat")
 	if error != nil {
 		return error
@@ -91,7 +91,7 @@ func readCPULoad(c *CPULoad) error {
 
 // UpdateCPULoad updates fields of the type CPULoad
 func (c *CPULoad) UpdateCPULoad() error {
-	err := readCPULoad(c)
+	err := c.readCPULoad()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Fixes #97 

1. Read `/proc/stat` to obtain CPU load information instead of relying on `mpstat`. No more dependency related errors on systems that don't have `mpstat` installed by default.

2. Updated CONTRIBUTING.MD to say `main` instead of `master` branch.

Let me know if there are any changes you would like :D 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [X] I have performed a self-review of my own code (if applicable)
- [X] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [X] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings 
- [ ] Any dependent and pending changes have been merged and published
