### PR TITLE
Changed trillion to billion and edge case is taken care

### DIFF
--- a/src/utils/dataFormat.go
+++ b/src/utils/dataFormat.go
@@ -25,6 +25,8 @@ var (
 	K = math.Pow(10, 3)
 	M = math.Pow(10, 6)
 	G = math.Pow(10, 9)
+	T = math.Pow(10, 12)
+	Q = math.Pow(10, 15)
 )
 
 func roundOffNearestTen(num float64, divisor float64) float64 {
@@ -58,10 +60,20 @@ func RoundValues(num1, num2 float64, inBytes bool) ([]float64, string) {
 		nums = append(nums, roundOffNearestTen(num2, M))
 		units = " per million "
 
-	case n >= G:
+	case n < T:
 		nums = append(nums, roundOffNearestTen(num1, G))
 		nums = append(nums, roundOffNearestTen(num2, G))
 		units = " per billion "
+
+	case n < Q:
+		nums = append(nums, roundOffNearestTen(num1, T))
+		nums = append(nums, roundOffNearestTen(num2, T))
+		units = " per trillion "
+
+	case n >= Q:
+		nums = append(nums, roundOffNearestTen(num1, Q))
+		nums = append(nums, roundOffNearestTen(num2, Q))
+		units = " per quadrillion "
 	}
 
 	if inBytes {
@@ -74,6 +86,10 @@ func RoundValues(num1, num2 float64, inBytes bool) ([]float64, string) {
 			units = " mB "
 		case " per billion ":
 			units = " gB "
+		case " per trillion ":
+			units = " tB "
+		case " per quadrillion ":
+			units = " pB "
 		}
 	}
 

--- a/src/utils/dataFormat.go
+++ b/src/utils/dataFormat.go
@@ -25,7 +25,6 @@ var (
 	K = math.Pow(10, 3)
 	M = math.Pow(10, 6)
 	G = math.Pow(10, 9)
-	T = math.Pow(10, 12)
 )
 
 func roundOffNearestTen(num float64, divisor float64) float64 {
@@ -59,10 +58,10 @@ func RoundValues(num1, num2 float64, inBytes bool) ([]float64, string) {
 		nums = append(nums, roundOffNearestTen(num2, M))
 		units = " per million "
 
-	case n < T:
+	case n >= G:
 		nums = append(nums, roundOffNearestTen(num1, G))
 		nums = append(nums, roundOffNearestTen(num2, G))
-		units = " per trillion "
+		units = " per billion "
 	}
 
 	if inBytes {
@@ -73,7 +72,7 @@ func RoundValues(num1, num2 float64, inBytes bool) ([]float64, string) {
 			units = " kB "
 		case " per million ":
 			units = " mB "
-		case " per trillion ":
+		case " per billion ":
 			units = " gB "
 		}
 	}

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -49,7 +49,7 @@ func TestRoundValues(t *testing.T) {
 			inBytes:             false,
 		},
 		{
-			expectedUnit:        " per trillion ",
+			expectedUnit:        " per billion ",
 			input:               []float64{100000000, 100000000000},
 			expectedRoundedVals: []float64{0.1, 100},
 			inBytes:             false,

--- a/src/utils/utils_test.go
+++ b/src/utils/utils_test.go
@@ -55,6 +55,18 @@ func TestRoundValues(t *testing.T) {
 			inBytes:             false,
 		},
 		{
+			expectedUnit:        " per trillion ",
+			input:               []float64{100000000000, 10000000000000},
+			expectedRoundedVals: []float64{0.1, 10},
+			inBytes:             false,
+		},
+		{
+			expectedUnit:        " per quadrillion ",
+			input:               []float64{100000000000000, 10000000000000000},
+			expectedRoundedVals: []float64{0.1, 10},
+			inBytes:             false,
+		},
+		{
 			expectedUnit:        " B ",
 			input:               []float64{999, 895},
 			expectedRoundedVals: []float64{999, 895},
@@ -76,6 +88,18 @@ func TestRoundValues(t *testing.T) {
 			expectedUnit:        " gB ",
 			input:               []float64{100000000, 100000000000},
 			expectedRoundedVals: []float64{0.1, 100},
+			inBytes:             true,
+		},
+		{
+			expectedUnit:        " tB ",
+			input:               []float64{100000000000, 10000000000000},
+			expectedRoundedVals: []float64{0.1, 10},
+			inBytes:             true,
+		},
+		{
+			expectedUnit:        " pB ",
+			input:               []float64{100000000000000, 10000000000000000},
+			expectedRoundedVals: []float64{0.1, 10},
 			inBytes:             true,
 		},
 	}


### PR DESCRIPTION
For the edge case (n >= T), numbers will be represented in terms of "gB" units. i.e. All numbers greater than or equal to 10^9 will be represented in terms of gigabytes (billion bytes). This resolves the edge case, if numbers were greater than 10^12, empty values would be returned.

Fixes #118 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [ ] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings 
- [ ] Any dependent and pending changes have been merged and published
