### PR TITLE
Custom Table Styling options

### DIFF
--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -149,7 +149,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 	tick := t.C
 
 	previousKey := ""
-	selectedStyle := ui.ColorCyan
+	selectedStyle := myPage.ProcTable.CursorColor
 	killingStyle := ui.ColorMagenta
 	errorStyle := ui.ColorRed
 
@@ -296,7 +296,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 
 		case data := <-dataChannel:
 			if runAllProc {
-				//myPage.ProcTable.CursorColor = selectedStyle
+				myPage.ProcTable.CursorColor = selectedStyle
 				procData := getData(data)
 				myPage.ProcTable.Rows = procData
 				if sortIdx != -1 {

--- a/src/display/process/allProcs.go
+++ b/src/display/process/allProcs.go
@@ -296,7 +296,7 @@ func AllProcVisuals(dataChannel chan []*proc.Process,
 
 		case data := <-dataChannel:
 			if runAllProc {
-				myPage.ProcTable.CursorColor = selectedStyle
+				//myPage.ProcTable.CursorColor = selectedStyle
 				procData := getData(data)
 				myPage.ProcTable.Rows = procData
 				if sortIdx != -1 {

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -189,7 +189,7 @@ func (page *AllProcPage) InitAllProc() {
 	page.ProcTable.ShowCursor = true
 	page.ProcTable.CursorColor = ui.ColorCyan
 	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorClear)
-	page.ProcTable.ColColor = []utils.CustomColColor{{ColNumber: 1, ColColor: ui.ColorGreen}}
+	page.ProcTable.ColColor[1] = ui.ColorGreen
 	page.ProcTable.BorderStyle.Fg = ui.ColorCyan
 	//page.ProcTable.HeaderStyle = ui.NewStyle(ui.ColorBlue, ui.ColorClear, ui.ModifierUnderline)
 

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -190,7 +190,6 @@ func (page *AllProcPage) InitAllProc() {
 	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorClear)
 	page.ProcTable.ColColor[1] = ui.ColorGreen
 	page.ProcTable.BorderStyle.Fg = ui.ColorCyan
-	page.ProcTable.CurCol = ui.ColorGreen
 	page.ProcTable.CursorColor = ui.ColorWhite
 	page.Grid.Set(
 		ui.NewRow(1.0, page.ProcTable),

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -188,7 +188,10 @@ func (page *AllProcPage) InitAllProc() {
 	}
 	page.ProcTable.ShowCursor = true
 	page.ProcTable.CursorColor = ui.ColorCyan
+	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorCyan)
+	page.ProcTable.ColColor = []utils.CustomColColor{{ColNumber: 1, ColColor: ui.ColorGreen}}
 	page.ProcTable.BorderStyle.Fg = ui.ColorCyan
+	page.ProcTable.HeaderStyle = ui.NewStyle(ui.ColorBlue, ui.ColorClear, ui.ModifierUnderline)
 
 	page.Grid.Set(
 		ui.NewRow(1.0, page.ProcTable),

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -187,11 +187,10 @@ func (page *AllProcPage) InitAllProc() {
 		}
 	}
 	page.ProcTable.ShowCursor = true
-	page.ProcTable.CursorColor = ui.ColorCyan
 	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorClear)
 	page.ProcTable.ColColor[1] = ui.ColorGreen
 	page.ProcTable.BorderStyle.Fg = ui.ColorCyan
-
+	page.ProcTable.CursorColor = ui.ColorWhite
 	page.Grid.Set(
 		ui.NewRow(1.0, page.ProcTable),
 	)

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -190,7 +190,6 @@ func (page *AllProcPage) InitAllProc() {
 	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorClear)
 	page.ProcTable.ColColor[1] = ui.ColorGreen
 	page.ProcTable.BorderStyle.Fg = ui.ColorCyan
-	page.ProcTable.CursorColor = ui.ColorWhite
 	page.Grid.Set(
 		ui.NewRow(1.0, page.ProcTable),
 	)

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -190,6 +190,7 @@ func (page *AllProcPage) InitAllProc() {
 	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorClear)
 	page.ProcTable.ColColor[1] = ui.ColorGreen
 	page.ProcTable.BorderStyle.Fg = ui.ColorCyan
+	page.ProcTable.CurCol = ui.ColorGreen
 	page.ProcTable.CursorColor = ui.ColorWhite
 	page.Grid.Set(
 		ui.NewRow(1.0, page.ProcTable),

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -188,10 +188,10 @@ func (page *AllProcPage) InitAllProc() {
 	}
 	page.ProcTable.ShowCursor = true
 	page.ProcTable.CursorColor = ui.ColorCyan
-	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorCyan)
+	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorClear)
 	page.ProcTable.ColColor = []utils.CustomColColor{{ColNumber: 1, ColColor: ui.ColorGreen}}
 	page.ProcTable.BorderStyle.Fg = ui.ColorCyan
-	page.ProcTable.HeaderStyle = ui.NewStyle(ui.ColorBlue, ui.ColorClear, ui.ModifierUnderline)
+	//page.ProcTable.HeaderStyle = ui.NewStyle(ui.ColorBlue, ui.ColorClear, ui.ModifierUnderline)
 
 	page.Grid.Set(
 		ui.NewRow(1.0, page.ProcTable),

--- a/src/display/process/init.go
+++ b/src/display/process/init.go
@@ -191,7 +191,6 @@ func (page *AllProcPage) InitAllProc() {
 	page.ProcTable.RowStyle = ui.NewStyle(ui.ColorClear)
 	page.ProcTable.ColColor[1] = ui.ColorGreen
 	page.ProcTable.BorderStyle.Fg = ui.ColorCyan
-	//page.ProcTable.HeaderStyle = ui.NewStyle(ui.ColorBlue, ui.ColorClear, ui.ModifierUnderline)
 
 	page.Grid.Set(
 		ui.NewRow(1.0, page.ProcTable),

--- a/src/utils/table.go
+++ b/src/utils/table.go
@@ -37,6 +37,7 @@ type Table struct {
 	Header []string
 	Rows   [][]string
 
+	// Different Styles for Header and Rows
 	HeaderStyle ui.Style
 	RowStyle    ui.Style
 
@@ -53,8 +54,9 @@ type Table struct {
 	SelectedItem string // used to keep the cursor on the correct item if the data changes
 	SelectedRow  int
 	TopRow       int // used to indicate where in the table we are scrolled at
-	ColColor     []CustomColColor
-	ColResizer   func()
+	// List of type CustomColColor which can store column number and color. Allows you to set different colors for different columns
+	ColColor   []CustomColColor
+	ColResizer func()
 }
 
 // NewTable returns a new Table instance
@@ -137,9 +139,10 @@ func (t *Table) Draw(buf *ui.Buffer) {
 			}
 		}
 		// prints each col of the row
-
+		tempColor := style.Fg
 		for i, width := range t.ColWidths {
-			style.Fg = t.RowStyle.Fg
+			style.Fg = tempColor
+			// Change Foreground color if the column number is in the ColColor list
 			for _, x := range t.ColColor {
 				if x.ColNumber == i {
 					style.Fg = x.ColColor

--- a/src/utils/table.go
+++ b/src/utils/table.go
@@ -42,6 +42,7 @@ type Table struct {
 
 	ShowCursor  bool
 	CursorColor ui.Color
+	CurCol      ui.Color
 
 	ShowLocation bool
 
@@ -65,7 +66,8 @@ func NewTable() *Table {
 		UniqueCol:   0,
 		ColResizer:  func() {},
 		ColColor:    make(map[int]ui.Color),
-		CursorColor: ui.ColorBlue,
+		CursorColor: ui.ColorGreen,
+		CurCol:      ui.ColorCyan,
 	}
 }
 
@@ -116,7 +118,7 @@ func (t *Table) Draw(buf *ui.Buffer) {
 		style := t.RowStyle
 		if t.ShowCursor {
 			if (t.SelectedItem == "" && rowNum == t.SelectedRow) || (t.SelectedItem != "" && t.SelectedItem == row[t.UniqueCol]) {
-				style.Fg = t.CursorColor
+				style.Fg = t.CurCol
 				style.Modifier = ui.ModifierReverse
 				for _, width := range t.ColWidths {
 					if width == 0 {
@@ -141,7 +143,7 @@ func (t *Table) Draw(buf *ui.Buffer) {
 			// Change Foreground color if the column number is in the ColColor list
 			if val, ok := t.ColColor[i]; ok {
 				if rowNum == t.SelectedRow {
-					style.Fg = t.CursorColor
+					style.Fg = t.CurCol
 				} else {
 					style.Fg = val
 				}

--- a/src/utils/table.go
+++ b/src/utils/table.go
@@ -65,6 +65,7 @@ func NewTable() *Table {
 		UniqueCol:   0,
 		ColResizer:  func() {},
 		ColColor:    make(map[int]ui.Color),
+		CursorColor: ui.ColorBlue,
 	}
 }
 
@@ -107,12 +108,10 @@ func (t *Table) Draw(buf *ui.Buffer) {
 		log.Printf("table widget TopRow value less than 0. TopRow: %v", t.TopRow)
 		return
 	}
-
 	// prints each row
 	for rowNum := t.TopRow; rowNum < t.TopRow+t.Inner.Dy()-1 && rowNum < len(t.Rows); rowNum++ {
 		row := t.Rows[rowNum]
 		y := (rowNum + 2) - t.TopRow
-
 		// prints cursor
 		style := t.RowStyle
 		if t.ShowCursor {
@@ -134,12 +133,18 @@ func (t *Table) Draw(buf *ui.Buffer) {
 			}
 		}
 		// prints each col of the row
-		tempColor := style.Fg
+		tempFgColor := style.Fg
+		tempBgColor := style.Bg
 		for i, width := range t.ColWidths {
-			style.Fg = tempColor
+			style.Fg = tempFgColor
+			style.Bg = tempBgColor
 			// Change Foreground color if the column number is in the ColColor list
 			if val, ok := t.ColColor[i]; ok {
-				style.Fg = val
+				if rowNum == t.SelectedRow {
+					style.Fg = t.CursorColor
+				} else {
+					style.Fg = val
+				}
 			}
 			if width == 0 {
 				continue

--- a/src/utils/table.go
+++ b/src/utils/table.go
@@ -65,7 +65,7 @@ func NewTable() *Table {
 		UniqueCol:   0,
 		ColResizer:  func() {},
 		ColColor:    make(map[int]ui.Color),
-		CursorColor: ui.ColorBlue,
+		CursorColor: ui.ColorCyan,
 	}
 }
 

--- a/src/utils/table.go
+++ b/src/utils/table.go
@@ -25,11 +25,6 @@ import (
 	ui "github.com/gizak/termui/v3"
 )
 
-type CustomColColor struct {
-	ColNumber int
-	ColColor  ui.Color
-}
-
 // Custom table widget
 type Table struct {
 	*ui.Block
@@ -54,8 +49,8 @@ type Table struct {
 	SelectedItem string // used to keep the cursor on the correct item if the data changes
 	SelectedRow  int
 	TopRow       int // used to indicate where in the table we are scrolled at
-	// List of type CustomColColor which can store column number and color. Allows you to set different colors for different columns
-	ColColor   []CustomColColor
+	// Map that stores custom column colors
+	ColColor   map[int]ui.Color
 	ColResizer func()
 }
 
@@ -69,7 +64,7 @@ func NewTable() *Table {
 		TopRow:      0,
 		UniqueCol:   0,
 		ColResizer:  func() {},
-		ColColor:    []CustomColColor{},
+		ColColor:    make(map[int]ui.Color),
 	}
 }
 
@@ -143,10 +138,8 @@ func (t *Table) Draw(buf *ui.Buffer) {
 		for i, width := range t.ColWidths {
 			style.Fg = tempColor
 			// Change Foreground color if the column number is in the ColColor list
-			for _, x := range t.ColColor {
-				if x.ColNumber == i {
-					style.Fg = x.ColColor
-				}
+			if val, ok := t.ColColor[i]; ok {
+				style.Fg = val
 			}
 			if width == 0 {
 				continue

--- a/src/utils/table.go
+++ b/src/utils/table.go
@@ -42,7 +42,6 @@ type Table struct {
 
 	ShowCursor  bool
 	CursorColor ui.Color
-	CurCol      ui.Color
 
 	ShowLocation bool
 
@@ -66,8 +65,7 @@ func NewTable() *Table {
 		UniqueCol:   0,
 		ColResizer:  func() {},
 		ColColor:    make(map[int]ui.Color),
-		CursorColor: ui.ColorGreen,
-		CurCol:      ui.ColorCyan,
+		CursorColor: ui.ColorBlue,
 	}
 }
 
@@ -118,7 +116,7 @@ func (t *Table) Draw(buf *ui.Buffer) {
 		style := t.RowStyle
 		if t.ShowCursor {
 			if (t.SelectedItem == "" && rowNum == t.SelectedRow) || (t.SelectedItem != "" && t.SelectedItem == row[t.UniqueCol]) {
-				style.Fg = t.CurCol
+				style.Fg = t.CursorColor
 				style.Modifier = ui.ModifierReverse
 				for _, width := range t.ColWidths {
 					if width == 0 {
@@ -143,7 +141,7 @@ func (t *Table) Draw(buf *ui.Buffer) {
 			// Change Foreground color if the column number is in the ColColor list
 			if val, ok := t.ColColor[i]; ok {
 				if rowNum == t.SelectedRow {
-					style.Fg = t.CurCol
+					style.Fg = t.CursorColor
 				} else {
 					style.Fg = val
 				}


### PR DESCRIPTION
# Description

Adds some fields to the custom Table widget that allows control over the styling. 
- New type `CustomColColor` that stores column number and color type.
- `ColColor` array. Appending to this array with {ColNumber: <int>, ColColor: <ui.Color>} will add custom colors to specified columns.
- `HeaderStyle` to allow changing of header style
- `RowStyle` to allow changing the default row style

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [X] I have performed a self-review of my own code (if applicable)
- [X] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [X] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings 
- [ ] Any dependent and pending changes have been merged and published
