### PR TITLE
Addition of version number to about.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Display Overall Metrics
 grofer [FLAGS]
 ```
 
-The command displays the default root page which provides verall CPU, Memory, Network and Disk Metrics.
+The command displays the default root page which provides overall CPU, Memory, Network and Disk Metrics.
 
 Optional flags:
 

--- a/cmd/about.go
+++ b/cmd/about.go
@@ -25,7 +25,7 @@ import (
 )
 
 // groferVersion is the version of grofer that is loaded in during build
-var groferVersion string
+var groferVersion string = "1.3.0"
 
 // aboutCmd represents the about command
 var aboutCmd = &cobra.Command{

--- a/cmd/about.go
+++ b/cmd/about.go
@@ -24,6 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var groferVersion string
+
 // aboutCmd represents the about command
 var aboutCmd = &cobra.Command{
 	Use:   "about",
@@ -42,6 +44,7 @@ var aboutCmd = &cobra.Command{
 		About.BorderStyle.Fg = ui.ColorBlue
 		About.Text =
 			"\nA system profiler written purely in golang!\n\n" +
+				"version: " + groferVersion + "\n\n" +
 				"Made with [♥](fg:red) by [PES Open Source](fg:green)\n\n"
 
 		uiEvents := ui.PollEvents()

--- a/cmd/about.go
+++ b/cmd/about.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// groferVersion is the version of grofer that is loaded in during build
 var groferVersion string
 
 // aboutCmd represents the about command


### PR DESCRIPTION

# Description

Version number is added as a hardcoded string (```groferVersion```) to ```About.text``` within the ```About``` widget, but it isn't initialized. While building, the version must be injected (as a string) to the package level variable ```groferVersion``` to avoid display of an empty string in place of version.


Fixes #117 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [ ] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [ ] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings 
- [ ] Any dependent and pending changes have been merged and published
