### PR TITLE
Removed "New" from "NewMetricScraperFactory" in a comment

### DIFF
--- a/pkg/metrics/factory/metrics_factory.go
+++ b/pkg/metrics/factory/metrics_factory.go
@@ -50,7 +50,7 @@ type MetricScraperFactory struct {
 	scrapeIntervalMillisecond uint64
 }
 
-// NewMetricScraperFactory is a constructor for the NewMetricScraperFactory type.
+// NewMetricScraperFactory is a constructor for the MetricScraperFactory type.
 // By default, this will be for the core.MainCommand command.
 func NewMetricScraperFactory() *MetricScraperFactory {
 	return &MetricScraperFactory{}


### PR DESCRIPTION
# Description

The comment on line 53 said:

```// NewMetricScraperFactory is a constructor for the NewMetricScraperFactory type.```

so I started looking around for a struct named _NewMetricScraperFactory_ lol.
When I came to find that there wasn't one, I was sure that it was supposed to be MetricScraperFactory


# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [ ] I have performed a self-review of my own code (if applicable)
- [ ] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [ ] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings 
- [ ] Any dependent and pending changes have been merged and published
