### PR TITLE
A new battery screen

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ const (
 	defaultOverallRefreshRate = 1000
 	defaultConfigFileLocation = ""
 	defaultCPUBehavior        = false
+	defaultBatteryBehaviour   = false
 )
 
 var cfgFile string
@@ -60,9 +61,16 @@ While using a TUI based command, press ? to get information about key bindings (
 			return err
 		}
 
-		err = systemWideMetricScraper.Serve(factory.WithCPUInfoAs(rootCmd.cpuInfo))
-		if err != nil && err != core.ErrCanceledByUser {
-			fmt.Printf("Error: %v\n", err)
+		if !rootCmd.batteryInfo {
+			err = systemWideMetricScraper.Serve(factory.WithCPUInfoAs(rootCmd.cpuInfo))
+			if err != nil && err != core.ErrCanceledByUser {
+				fmt.Printf("Error: %v\n", err)
+			}
+		} else {
+			err = systemWideMetricScraper.Serve(factory.WithBatteryInfoAs(rootCmd.batteryInfo))
+			if err != nil && err != core.ErrCanceledByUser {
+				fmt.Printf("Error: %v\n", err)
+			}
 		}
 
 		return nil
@@ -72,6 +80,7 @@ While using a TUI based command, press ? to get information about key bindings (
 type rootCommand struct {
 	refreshRate uint64
 	cpuInfo     bool
+	batteryInfo bool
 }
 
 func constructRootCommand(cmd *cobra.Command, args []string) (*rootCommand, error) {
@@ -89,9 +98,15 @@ func constructRootCommand(cmd *cobra.Command, args []string) (*rootCommand, erro
 		return nil, err
 	}
 
+	batteryInfo, err := cmd.Flags().GetBool("battery")
+	if err != nil {
+		return nil, err
+	}
+
 	return &rootCommand{
 		refreshRate: refreshRate,
 		cpuInfo:     cpuInfo,
+		batteryInfo: batteryInfo,
 	}, nil
 }
 
@@ -123,6 +138,13 @@ func init() {
 		"c",
 		defaultCPUBehavior,
 		"Info about the CPU Load over all CPUs",
+	)
+
+	rootCmd.Flags().BoolP(
+		"battery",
+		"b",
+		defaultBatteryBehaviour,
+		"All stats about the battery.",
 	)
 }
 

--- a/pkg/metrics/factory/options.go
+++ b/pkg/metrics/factory/options.go
@@ -34,3 +34,11 @@ func WithCPUInfoAs(cpuInfo bool) Option {
 		swm.cpuInfo = cpuInfo
 	}
 }
+
+// WithBatteryInfoAs sets the battery flag value for the RootCommand.
+func WithBatteryInfoAs(batteryInfo bool) Option {
+	return func(ms MetricScraper) {
+		swm := ms.(*systemWideMetrics)
+		swm.batteryInfo = batteryInfo
+	}
+}

--- a/pkg/metrics/general/battery_info.go
+++ b/pkg/metrics/general/battery_info.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2020 The PES Open Source Team pesos@pes.edu
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package general
 
 import (

--- a/pkg/metrics/general/battery_info.go
+++ b/pkg/metrics/general/battery_info.go
@@ -1,0 +1,111 @@
+package general
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/pesos/grofer/pkg/utils"
+)
+
+type BatteryInfo struct {
+	Manufacturer         string `json:"manufacturer"`
+	Technology           string `json:"technology"`
+	ModelName            string `json:"model_name"`
+	SerialNumber         string `json:"serial_number"`
+	Capacity             string `json:"capacity"`
+	CycleCount           string `json:"cycle_count"`
+	EnergyFullDesign     string `json:"energy_full_design"`
+	EnergyFull           string `json:"energy_full"`
+	EnergyNow            string `json:"energy_now"`
+	PowerNow             string `json:"power_now"`
+	Status               string `json:"status"`
+	ChargeStartThreshold string `json:"charge_start_threshold"`
+	ChargeStopThreshold  string `json:"charge_stop_threshold"`
+}
+
+type BatteryData struct {
+	Battery [][]string
+}
+
+// NewBatteryInfo is a constructor for the BatteryInfo type.
+func NewBatteryInfo() *BatteryInfo {
+	return &BatteryInfo{}
+}
+
+// GetBatteryInfo updates the BatteryInfo struct and serves the data to the data channel.
+func GetBatteryInfo(ctx context.Context, batteryInfo *BatteryInfo, dataChannel chan BatteryData, refreshRate uint64) error {
+	return utils.TickUntilDone(ctx, refreshRate, func() error {
+		err := batteryInfo.UpdateBatteryInfo()
+		batteryData := batteryInfo.getBatteryData()
+		if err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case dataChannel <- batteryData:
+			return nil
+		}
+	})
+}
+
+// UpdateBatteryInfo updates fields of the type BatteryInfo
+func (c *BatteryInfo) UpdateBatteryInfo() error {
+	err := c.readBatteryInfo()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ReadBatteryInfo reads files from /sys/class/power_supply/BAT0
+// and returns battery specific stats
+func (c *BatteryInfo) readBatteryInfo() error {
+	val := reflect.ValueOf(c).Elem()
+	for i := 0; i < val.Type().NumField(); i++ {
+		fileName := val.Type().Field(i).Tag.Get("json")
+		file, err := os.Open("/sys/class/power_supply/BAT0/" + fileName)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		reader := bufio.NewReader(file)
+
+		// Read first line containing load values
+		data, err := reader.ReadBytes(byte('\n'))
+		if err != nil {
+			return err
+		}
+		vals := strings.Fields(string(data))
+		val.FieldByName(val.Type().Field(i).Name).SetString(vals[0])
+	}
+	return nil
+}
+
+// getBatteryData structures all the battery stats into the Battery data struct.
+func (c *BatteryInfo) getBatteryData() BatteryData {
+	var bData BatteryData = BatteryData{
+		Battery: [][]string{
+			{"Stats", "Info"},
+			{"manufacturer", c.Manufacturer},
+			{"technology", c.Technology},
+			{"model name", c.ModelName},
+			{"serial number", c.SerialNumber},
+			{"capacity", c.Capacity},
+			{"cycle count", c.CycleCount},
+			{"energy full design", c.EnergyFullDesign},
+			{"energy full", c.EnergyFull},
+			{"energy now", c.EnergyNow},
+			{"power now", c.PowerNow},
+			{"status", c.Status},
+			{"charge start threshold", c.ChargeStartThreshold},
+			{"charge stop threshold", c.ChargeStopThreshold},
+		},
+	}
+	return bData
+}

--- a/pkg/sink/tui/general/init.go
+++ b/pkg/sink/tui/general/init.go
@@ -442,7 +442,7 @@ func (page *CPUPage) init(numCores int) {
 }
 
 func (page *BatteryPage) initBatteryTableWidget() {
-	page.Battery.Title = " Battery Info"
+	page.Battery.Title = " Battery Stats Not Found "
 	page.Battery.TitleStyle = ui.NewStyle(ui.ColorClear)
 	page.Battery.BorderStyle.Fg = ui.ColorCyan
 	page.Battery.HeaderStyle = ui.NewStyle(ui.ColorClear, ui.ColorClear, ui.ModifierBold)
@@ -461,8 +461,8 @@ func (page *BatteryPage) initPageGrid() {
 			ui.NewRow(0.3, page.Battery),
 		),
 	)
-	// w, h := ui.TerminalDimensions()
-	page.Grid.SetRect(0, 0, 200, 55)
+	w, h := ui.TerminalDimensions()
+	page.Grid.SetRect(0, 0, w, h)
 }
 
 func (page *BatteryPage) init() {

--- a/pkg/sink/tui/general/init.go
+++ b/pkg/sink/tui/general/init.go
@@ -54,6 +54,12 @@ type CPUPage struct {
 	CPUTable    *viz.Table
 }
 
+// BatteryPage contains the UI widgets for the UI rendered by the grofer -b command
+type BatteryPage struct {
+	Grid    *ui.Grid
+	Battery *viz.Table
+}
+
 // NewPage returns a new page initialized from the MainPage struct
 func NewPage(numCores int) *MainPage {
 	rxSparkLine := viz.NewSparkline()
@@ -92,6 +98,16 @@ func NewCPUPage(numCores int) *CPUPage {
 		CPUTable:    viz.NewTable(),
 	}
 	page.init(numCores)
+	return page
+}
+
+// NewBatteryPage is a constructor for the BatteryPage type
+func NewBatteryPage() *BatteryPage {
+	page := &BatteryPage{
+		Grid:    ui.NewGrid(),
+		Battery: viz.NewTable(),
+	}
+	page.init()
 	return page
 }
 
@@ -423,4 +439,33 @@ func (page *CPUPage) init(numCores int) {
 	w, h := ui.TerminalDimensions()
 	page.Grid.SetRect(0, 0, w, h)
 
+}
+
+func (page *BatteryPage) initBatteryTableWidget() {
+	page.Battery.Title = " Battery Info"
+	page.Battery.TitleStyle = ui.NewStyle(ui.ColorClear)
+	page.Battery.BorderStyle.Fg = ui.ColorCyan
+	page.Battery.HeaderStyle = ui.NewStyle(ui.ColorClear, ui.ColorClear, ui.ModifierBold)
+	page.Battery.ShowCursor = false
+	page.Battery.ColResizer = func() {
+		x := page.Battery.Inner.Dx()
+		page.Battery.ColWidths = []int{x / 2, x / 2}
+	}
+}
+
+func (page *BatteryPage) initPageGrid() {
+	page.Grid = ui.NewGrid()
+	page.Grid.Set(
+		ui.NewCol(
+			0.3,
+			ui.NewRow(0.3, page.Battery),
+		),
+	)
+	// w, h := ui.TerminalDimensions()
+	page.Grid.SetRect(0, 0, 200, 55)
+}
+
+func (page *BatteryPage) init() {
+	page.initBatteryTableWidget()
+	page.initPageGrid()
 }

--- a/pkg/sink/tui/general/overall_graphs.go
+++ b/pkg/sink/tui/general/overall_graphs.go
@@ -429,8 +429,8 @@ func RenderCPUinfo(ctx context.Context, dataChannel chan *general.CPULoad, refre
 // RenderBatteryinfo displays the Battery info page
 func RenderBatteryinfo(ctx context.Context, dataChannel chan general.BatteryData, refreshRate uint64) error {
 	var on sync.Once
+	var pageRender bool = false
 	var help *misc.HelpMenu = misc.NewHelpMenu().ForCommand(misc.RootCommand)
-
 	if err := ui.Init(); err != nil {
 		return fmt.Errorf("failed to initialize termui: %v", err)
 	}
@@ -447,13 +447,18 @@ func RenderBatteryinfo(ctx context.Context, dataChannel chan general.BatteryData
 
 	// Re render UI
 	updateUI := func() {
-		w, h := ui.TerminalDimensions()
-		page.Grid.SetRect(0, 0, 200, 55)
+		var w, h int
+		if !pageRender {
+			w, h = ui.TerminalDimensions()
+		} else {
+			w, h = 200, 55
+		}
+		page.Grid.SetRect(0, 0, w, h)
 
 		ui.Clear()
-
 		switch utilitySelected {
 		case core.Help:
+			w, h = ui.TerminalDimensions()
 			help.Resize(w, h)
 			ui.Render(help)
 		default:
@@ -476,9 +481,6 @@ func RenderBatteryinfo(ctx context.Context, dataChannel chan general.BatteryData
 			case "q", "<C-c>": // q or Ctrl-C to quit
 				return core.ErrCanceledByUser
 
-			case "<Resize>":
-				updateUI()
-
 			case "<Escape>":
 				utilitySelected = core.None
 
@@ -491,9 +493,16 @@ func RenderBatteryinfo(ctx context.Context, dataChannel chan general.BatteryData
 			updateUI()
 		case data := <-dataChannel:
 			if run {
-				header, rows := data.Battery[0], data.Battery[1:]
-				page.Battery.Header = header
-				page.Battery.Rows = rows
+				switch data.FieldSet {
+				case "BATTERY":
+					page.Battery.Title = " Battery Info "
+					header, rows := data.Battery[0], data.Battery[1:]
+					page.Battery.Header = header
+					page.Battery.Rows = rows
+					pageRender = true
+				default:
+					pageRender = false
+				}
 				on.Do(updateUI)
 			}
 		case <-tick:


### PR DESCRIPTION
Description

Added a new screen to track battery-related information. It can be accessed using the 'battery' flag.

Fixes #126 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update 

# Checklist:

- [x] I have read the [contribution guidelines](https://github.com/pesos/grofer/blob/master/CONTRIBUTING.md) and followed it as far as possible. 
- [x] I have performed a self-review of my own code (if applicable)
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have run `go fmt` on my code ([reference](https://blog.golang.org/gofmt))
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings 
- [ ] Any dependent and pending changes have been merged and published
